### PR TITLE
Include full path to `toggle_color_mode` in code example

### DIFF
--- a/pcweb/pages/docs/styling/theming.py
+++ b/pcweb/pages/docs/styling/theming.py
@@ -23,7 +23,7 @@ def theming():
         docheader("Theming", first=True),
         doctext(
             "You can also add a dark mode toggle by adding ",
-            pc.code("pc.toggle_color_mode"),
+            pc.code("pc.style.toggle_color_mode"),
             " to an event trigger. This will change the whole app to dark mode. ",
         ),
         doctext(
@@ -33,7 +33,7 @@ def theming():
             """
             pc.button(
                 pc.icon(tag="moon"),
-                on_click=pc.toggle_color_mode,
+                on_click=pc.style.toggle_color_mode,
             )
             """
         ),


### PR DESCRIPTION
Change the code example of `toggle_color_mode` to include the full path to the module. This avoids [the `reportPrivateImportUsage` error from pyright.](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportPrivateImportUsage)

Example when importing:
![image](https://user-images.githubusercontent.com/52338810/229507741-49d76c4e-7792-4c97-9f65-f6cfa19e0eca.png)

Example in code:
![image](https://user-images.githubusercontent.com/52338810/229507963-2d323243-d799-4b03-b541-b7d02810a8c3.png)

