### PR TITLE
Document next/script component

### DIFF
--- a/pcweb/component_list.py
+++ b/pcweb/component_list.py
@@ -189,7 +189,7 @@ graphing_list = [
 ]
 
 # Other
-other_list = [[rx.Html]]
+other_list = [[rx.Html], [rx.Script]]
 
 # The final component list
 component_list = {

--- a/pcweb/pages/docs/component.py
+++ b/pcweb/pages/docs/component.py
@@ -257,6 +257,9 @@ EVENTS = {
     "on_copy": {
         "description": "The on_copy event handler is called in CopyToClipboard component"
     },
+    "on_ready": {
+        "description": "The on_ready event handler is called when the script is ready to be executed."
+    }
 }
 
 

--- a/pcweb/pages/docs/component_lib/other.py
+++ b/pcweb/pages/docs/component_lib/other.py
@@ -1,7 +1,8 @@
 import reflex as rx
 
 from pcweb.base_state import State
-from pcweb.templates.docpage import docdemo, doctext
+from pcweb.templates.docpage import doccode, docdemo, doclink, doctext, subheader
+from pcweb.pages.docs.styling.overview import styling_overview
 
 example = """rx.vstack(
     rx.html("<h1>Hello World</h1>"),
@@ -30,7 +31,115 @@ def render_html():
         ),
         docdemo(example),
         doctext(
+            rx.alert(
+                rx.alert_icon(),
+                rx.box(
+                    rx.alert_title("Missing Styles?"),
+                    rx.alert_description(
+                        "Reflex uses Chakra-UI and Tailwind for styling, both of ",
+                        "which reset default styles for headings. If you are ",
+                        "using the html component and want pretty default ",
+                        "styles, consider setting ",
+                        rx.code('class_name="prose"'),
+                        ", adding ",
+                        rx.code("@tailwindcss/typography"),
+                        " package to ",
+                        rx.code("frontend_packages"),
+                        " and enabling it via ",
+                        rx.code("tailwind"),
+                        " config in ",
+                        rx.code("rxconfig.py"),
+                        ". See the ",
+                        doclink("Tailwind docs", href=styling_overview.path),
+                        " for an example of adding this plugin.",
+                    ),
+                ),
+            ),
+        ),
+        doctext(
             "Here is another example of the HTML component. In this example, we render an image."
         ),
         docdemo(example2),
+    )
+
+
+script_example = """rx.script("console.log('inline javascript')")"""
+
+script_example2 = """rx.script(src="/my-custom.js")"""
+
+script_example3 = """rx.script(src="//gc.zgo.at/count.js", custom_attrs={"data-goatcounter": "https://reflextoys.goatcounter.com/count"}),"""
+
+script_example4 = """rx.vstack(
+    rx.script(
+        '''const handle_press = (arg) => {
+            window.alert("You clicked at " + arg.clientX + ", " + arg.clientY);
+        }'''
+    ),
+    rx.button("Where Did I Click?", on_click=rx.client_side("handle_press(args)")),
+)
+"""
+
+
+def render_script():
+    return rx.vstack(
+        doctext(
+            "The Script component can be used to include inline javascript or javascript files by URL. ",
+            "It uses the ",
+            rx.link(
+                "next/script component",
+                href="https://nextjs.org/docs/app/api-reference/components/script",
+            ),
+            " to inject the script and can be safely used with conditional rendering ",
+            "to allow script side effects to be controlled by the state.",
+        ),
+        doccode(script_example),
+        doctext(
+            "Complex inline scripting should be avoided. If the code to be included is more than a couple lines, ",
+            "it is more maintainable ",
+            "to implement it in a separate javascript file in the ",
+            rx.code("assets"),
+            " directory and include it via the ",
+            rx.code("src"),
+            " prop.",
+        ),
+        doccode(script_example2),
+        doctext(
+            "This component is particularly helpful for including tracking and social scripts. Any additional attrs needed ",
+            "for the script tag can be supplied via ",
+            rx.code("custom_attrs"),
+            " prop.",
+        ),
+        doccode(script_example3),
+        doctext(
+            "This code renders to something like the following to enable stat counting with a third party service."
+        ),
+        doccode(
+            '<script src="//gc.zgo.at/count.js" data-goatcounter="https://reflextoys.goatcounter.com/count" data-nscript="afterInteractive"></script>',
+            language="html",
+        ),
+        subheader("Client Side Events"),
+        doctext(
+            "The provided ",
+            rx.code("rx.client_side"),
+            " event handler can be used to execute arbitrary javascript code in response to UI events. ",
+            "The handler may call functions defined in previous ",
+            rx.code("rx.script"),
+            " components.",
+        ),
+        docdemo(script_example4),
+        doctext(
+            rx.alert(
+                rx.alert_icon(),
+                rx.box(
+                    rx.alert_title("Avoid Recreating the Wheel"),
+                    rx.alert_description(
+                        "This snippet uses ",
+                        rx.code("window.alert"),
+                        " directly as an example. Users should generally avoid inline javascript where Reflex provides an "
+                        "alternative, like ",
+                        rx.code("rx.window_alert"),
+                    ),
+                ),
+            ),
+        ),
     )


### PR DESCRIPTION
# New warning on Html page

![image](https://github.com/reflex-dev/reflex-web/assets/1524005/058d997e-8bd9-4fdb-99d4-05ca0ded5a47)

# All New `rx.script` docs and examples

![image](https://github.com/reflex-dev/reflex-web/assets/1524005/07527e04-93ef-48b4-a52d-d660b64c240d)
![image](https://github.com/reflex-dev/reflex-web/assets/1524005/7f572bc0-3abb-4b98-866e-8eae218a9264)
![image](https://github.com/reflex-dev/reflex-web/assets/1524005/6ae0f2d1-d8a2-4998-b719-4f09ab512d40)
![image](https://github.com/reflex-dev/reflex-web/assets/1524005/bc1976c9-b54b-4058-bdff-9b46d61442dd)

Not sure why the docstring is rendering with monospace text like that 🤔 leading 4 spaces maybe interpreted by markdown as a code block?

```python
class Script(Component):
    """Next.js script component.

    Note that this component differs from reflex.components.base.document.NextScript
    in that it is intended for use with custom and user-defined scripts.

    It also differs from reflex.components.base.link.ScriptTag, which is the plain
    HTML <script> tag which does not work when rendering a component.
    """

    library = "next/script"
    tag = "Script"
    is_default = True
```