### PR TITLE
The property api_key is updated.

### DIFF
--- a/pcweb/pages/docs/tutorial/final_app.py
+++ b/pcweb/pages/docs/tutorial/final_app.py
@@ -13,7 +13,7 @@ state1 = """# state.py
 import os
 import openai
 
-openai.API_KEY = os.environ["OPENAI_API_KEY"]
+openai.api_key = os.environ["OPENAI_API_KEY"]
 
 ...
 


### PR DESCRIPTION
In the tutorial, the property name api_key from OpenAI has been used in uppercase. The property only exists in lowercase.