### PR TITLE
Fix reflex chat tutorial mistake in the streaming answer code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pcweb/tsclient.py
 pynecone.db
 reflex.db
 venv/
+.mypy_cache/

--- a/pcweb/pages/docs/tutorial/adding_state.py
+++ b/pcweb/pages/docs/tutorial/adding_state.py
@@ -107,7 +107,7 @@ def chat() -> rx.Component:
             lambda messages: qa(messages[0], messages[1])
         )
     )
-    
+
 ...
 
 def action_bar() -> rx.Component:
@@ -158,7 +158,7 @@ async def answer(self):
         # Pause to show the streaming effect.
         await asyncio.sleep(0.1)
         # Add one letter at a time to the output.
-        self.chat_history[-1] = (self.question, answer[:i])
+        self.chat_history[-1] = (self.question, answer[:i+1])
         yield
 """
 def action_bar3() -> rx.Component:


### PR DESCRIPTION
## Summary
- Fix reflex chat tutorial mistake in the streaming answer code:
   self.chat_history[-1] = (self.question, answer[:i]) -> self.chat_history[-1] = (self.question, answer[:i+1])

## Tests
- Run the site locally and check the changed content (right is local)

<img width="1496" alt="image" src="https://github.com/reflex-dev/reflex-web/assets/15661672/025b7a1e-ac29-4d23-815d-b43c92754cb4">
