### PR TITLE
fix broken href to api-reference/var

### DIFF
--- a/pcweb/pages/docs/state/vars.py
+++ b/pcweb/pages/docs/state/vars.py
@@ -198,9 +198,11 @@ def index():
                     rx.alert_description(
                         "They can be used for arithemtic, string concatenation, inequalities, indexing, and more. "
                         "See the ",
-                        doclink("full list of supported operations", "/api-reference/var"),
+                        doclink(
+                            "full list of supported operations",
+                            "/docs/api-reference/var",
+                        ),
                         ".",
-
                     ),
                 ),
                 status="success",


### PR DESCRIPTION
## Summary
The reference to api-reference var page on `docs/state/vars/` is a broken link.