### PR TITLE
Added warning for macOS users using Apple Silicon

### DIFF
--- a/pcweb/pages/docs/getting_started/installation.py
+++ b/pcweb/pages/docs/getting_started/installation.py
@@ -27,6 +27,12 @@ def installation():
             " for optimal performance.",
             status="warning",
         ),
+        docalert(
+            "For macOS users with Apple M1 or M2 chips, you may need to install Rosetta 2"
+            " to run Reflex. This can be done with the following command:",
+            rx.code("/usr/sbin/softwareupdate --install-rosetta --agree-to-license"),
+            status="warning",
+        ),
         rx.divider(),
         subheader("Virtual Environment (Optional)"),
         doctext(


### PR DESCRIPTION
Thanks to the help of @masenf, this [issue](https://github.com/reflex-dev/reflex/issues/1803) has been resolved. The new package manager `fnm` seems to require `Rosetta 2` to work. As this may be crucial for developers using Apple silicon chips, I think it makes sense to add this information to the installation guide. In case other users encounter the same problem.

You can see the changes in the image below, let me know if you don't like the wording or styling. I tried the `doccode` component, but it does not look good inside the alert component. So I used the regular `rx.code` component.

<img width="808" alt="Screenshot 2023-09-13 at 06 39 27" src="https://github.com/reflex-dev/reflex-web/assets/71128266/eb5281ec-8200-4678-be23-3b233c05a795">
