### PR TITLE
[WiP] scope all flexdown exec and eval in the pcweb.flexdown_scope module

### DIFF
--- a/blog/2023-06-28-rebrand-to-reflex.md
+++ b/blog/2023-06-28-rebrand-to-reflex.md
@@ -35,7 +35,7 @@ doctext("If you have an existing Pynecone project, run ", rx.code("reflex init")
 ### Next Steps
 
 ```reflex
-doctext("If you have any issues through the migration, please come join our ", doclink("Discord", href=constants.DISCORD_URL), ". We will post the latest news there as well as on our ", doclink("Twitter", href=constants.TWITTER_URL), ".")
+doctext("If you have any issues through the migration, please come join our ", doclink("Discord", href=pcweb.constants.DISCORD_URL), ". We will post the latest news there as well as on our ", doclink("Twitter", href=pcweb.constants.TWITTER_URL), ".")
 ```
 
 Thanks for supporting us through this change. We're excited to start this new chapter and see what the community builds with Reflex!

--- a/docs/advanced-guide/01-background-tasks.md
+++ b/docs/advanced-guide/01-background-tasks.md
@@ -1,7 +1,5 @@
 ---
-from pcweb import constants, styles
 from pcweb.base_state import State
-from pcweb.templates.docpage import docalert, doccode, docheader, subheader, docdemobox
 from pcweb.pages.docs.advanced_guide.background_tasks import LowLevelState, low_level_code, low_level_render_code, MyTaskState, my_task_code, my_task_render_code
 ---
 

--- a/docs/getting-started/01-introduction.md
+++ b/docs/getting-started/01-introduction.md
@@ -1,7 +1,6 @@
 ---
-from pcweb import constants, styles
+from pcweb import styles
 from pcweb.base_state import State
-from pcweb.templates.docpage import docalert, doccode, docheader, subheader, docdemobox
 from pcweb.pages.docs.getting_started.introduction import CounterExampleState, counter_code
 ---
 

--- a/docs/getting-started/02-installation.md
+++ b/docs/getting-started/02-installation.md
@@ -1,7 +1,3 @@
----
-from pcweb import constants
----
-
 # Installation
 
 ## Prerequisites
@@ -21,12 +17,12 @@ We recommend creating a virtual environment for your project.
 
 Below are some tools you can use to manage environments:
 
-- [venv]({constants.VENV_URL})
-- [poetry]({constants.POETRY_URL})
+- [venv]({pcweb.constants.VENV_URL})
+- [poetry]({pcweb.constants.POETRY_URL})
 
 ## Installing
 
-Reflex is available as a [pip](constants.PIP_URL) package.
+Reflex is available as a [pip](pcweb.constants.PIP_URL) package.
 
 ```bash
 pip install reflex

--- a/docs/library/layout/fragment.md
+++ b/docs/library/layout/fragment.md
@@ -1,8 +1,4 @@
 ---
-import reflex as rx
-from pcweb import constants
-from pcweb.templates.docpage import docdemo
-
 fragment_example = """rx.fragment(
     rx.text("Component1"), 
     rx.text("Component2")
@@ -12,7 +8,7 @@ fragment_example = """rx.fragment(
 
 A Fragment is a Component that allow you to group multiple Components without a wrapper node.
 
-Refer to the React docs at [React/Fragment]({constants.FRAGMENT_COMPONENT_INFO_URL}) for more information on its use-case.
+Refer to the React docs at [React/Fragment]({pcweb.constants.FRAGMENT_COMPONENT_INFO_URL}) for more information on its use-case.
 
 ```reflex
 docdemo(fragment_example)

--- a/pcweb/flexdown.py
+++ b/pcweb/flexdown.py
@@ -6,7 +6,7 @@ import yaml
 
 import reflex as rx
 
-from pcweb import constants, styles
+from pcweb import constants, flexdown_scope, styles
 from pcweb.templates.docpage import doccode, docheader, docheader2, doclink, doctext, subheader, subheader2, subheader3, doclink2
 
 
@@ -70,11 +70,11 @@ def parse(source: str, md=md):
     """
     front_matter, source = parse_markdown_front_matter(source)
     if isinstance(front_matter, str):
-        exec(front_matter)
+        exec(front_matter, flexdown_scope.SCOPE)
     elif isinstance(front_matter, dict):
         py_front_matter, source = parse_markdown_front_matter(source)
         if isinstance(py_front_matter, str):
-            exec(py_front_matter)
+            exec(py_front_matter, flexdown_scope.SCOPE)
 
     lines = source.split("\n")
     output = []
@@ -95,14 +95,14 @@ def parse(source: str, md=md):
             # End reflex block.
             in_reflex_block = False
             try:
-                result = eval("\n".join(current_block))
+                result = eval("\n".join(current_block), flexdown_scope.SCOPE)
             except Exception as e:
                 print(f"Error in reflex block: {str(e)}")
                 sys.exit(1)
             output.append(result)
             current_block = []
         else:
-            current_block.append(evaluate_template_string(line, scope=locals()))
+            current_block.append(evaluate_template_string(line, scope=flexdown_scope.SCOPE))
 
     return front_matter, output
 

--- a/pcweb/flexdown_scope.py
+++ b/pcweb/flexdown_scope.py
@@ -1,0 +1,6 @@
+import reflex as rx
+import pcweb.constants
+
+from pcweb.templates.docpage import doccode, docdemobox, docheader, docheader2, doclink, doctext, subheader, subheader2, subheader3, doclink2
+
+SCOPE = globals()


### PR DESCRIPTION
flexdown_scope is explicitly defined to catch all definitions across all flexdown files. It's a module instead of just a normal dict so that it appears in `sys.modules` and can be used for our hokey state lookup.