### PR TITLE
Migrate to flexdown package

### DIFF
--- a/docs/getting-started/02-installation.md
+++ b/docs/getting-started/02-installation.md
@@ -1,6 +1,8 @@
----
+```python exec
 from pcweb import constants
----
+app_name = "my_app_name"
+default_url = "http://localhost:3000"
+```
 
 # Installation
 
@@ -36,11 +38,11 @@ pip install reflex
 
 Installing Reflex also installs the `reflex` command line tool.
 
-Test that the install was successful by creating a new project. Replace `my_app_name` with your project name:
+Test that the install was successful by creating a new project. Replace `{app_name}` with your project name:
 
 ```bash
-$ mkdir my_app_name
-$ cd my_app_name
+$ mkdir {app_name}
+$ cd {app_name}
 $ reflex init
 ```
 
@@ -58,7 +60,7 @@ You should see your app running at [http://localhost:3000](http://localhost:3000
 
 ## Fast Refresh
 
-Reflex has fast refreshes when running in development mode. You can modify the source code in `my_app_name/my_app_name.py` and see your changes in the browser instantly when you save your code.
+Reflex has fast refreshes when running in development mode. You can modify the source code in `{app_name}/{app_name}.py` and see your changes in the browser instantly when you save your code.
 
 ## Debugging
 

--- a/docs/library/forms/form.md
+++ b/docs/library/forms/form.md
@@ -1,4 +1,4 @@
----
+```python exec
 import reflex as rx
 from pcweb.base_state import State
 from pcweb.templates.docpage import docdemo
@@ -32,7 +32,8 @@ form_example = """rx.vstack(
     rx.text(FormState.form_data.to_string()),
 )"""
 
----
+```
+
 Forms are used to collect user input. The `rx.form` component is used to group inputs and submit them together.
 
 
@@ -41,7 +42,7 @@ The form component's children can be form controls such as `rx.input`, `rx.check
 The form is submitted when the user clicks the submit button or presses enter on the form controls.
 
 
-```reflex
+```python eval
 docdemo(form_example,
         state=form_state,
         comp=eval(form_example),
@@ -49,7 +50,7 @@ docdemo(form_example,
 )
 ```
 
-```reflex
+```python eval
 rx.alert(
     rx.alert_icon(),
     rx.alert_title(

--- a/docs/library/graphing/area_chart.md
+++ b/docs/library/graphing/area_chart.md
@@ -1,4 +1,4 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo, docgraphing
 
@@ -150,14 +150,13 @@ range_area_chart = """rx.area_chart(
                 rx.x_axis(data_key="day"), 
                 rx.y_axis(),
                 data=range_data)"""
----
-
+```
 
 An area chart combines the line chart and bar chart to show how one or more groups’ numeric values change over the progression of a second variable, typically that of time. An area chart is distinguished from a line chart by the addition of shading between lines and a baseline, like in a bar chart.
 
 For an area chart we must define an `rx.area()` component that has a `data_key` which clearly states which variable in our data we are tracking. In this simple example we track `uv` against `name` and therefore set the `rx.x_axis` to equal `name`.
 
-```reflex
+```python eval
 docgraphing(
   area_chart_example, 
   comp = eval(area_chart_example),
@@ -167,7 +166,7 @@ docgraphing(
 
 Multiple areas can be placed on the same `area_chart`.
 
-```reflex
+```python eval
 docgraphing(
   area_chart_example_2, 
   comp = eval(area_chart_example_2),
@@ -177,7 +176,7 @@ docgraphing(
 
 You can also assign a range in the area by assiging the data_key in the `rx.area` to a list with two elements, i.e. here a range of two temperatures for each date.
 
-```reflex
+```python eval
 docgraphing(
   area_chart_example_2, 
   comp = eval(range_area_chart),

--- a/docs/library/graphing/bar_chart.md
+++ b/docs/library/graphing/bar_chart.md
@@ -1,4 +1,4 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo, docgraphing
 
@@ -114,7 +114,6 @@ range_data = [
 ]
 
 
-
 bar_chart_example = """rx.bar_chart(
                 rx.bar(
                     data_key="uv",
@@ -150,7 +149,7 @@ range_bar_chart = """rx.bar_chart(
                 rx.x_axis(data_key="day"), 
                 rx.y_axis(),
                 data=range_data)"""
----
+```
 
 
 A bar chart presents categorical data with rectangular bars with heights or lengths proportional to the values that they represent.
@@ -158,7 +157,7 @@ A bar chart presents categorical data with rectangular bars with heights or leng
 For a bar chart we must define an `rx.bar()` component for each set of values we wish to plot. Each `rx.bar()` component has a `data_key` which clearly states which variable in our data we are tracking. In this simple example we plot `uv` as a bar against the `name` column which we set as the `data_key` in `rx.x_axis`.
 
 
-```reflex
+```python eval
 docgraphing(
   bar_chart_example, 
   comp = eval(bar_chart_example),
@@ -168,7 +167,7 @@ docgraphing(
 
 Multiple bars can be placed on the same `bar_chart`, using multiple `rx.bar()` components.
 
-```reflex
+```python eval
 docgraphing(
   bar_chart_example_2, 
   comp = eval(bar_chart_example_2),
@@ -178,7 +177,7 @@ docgraphing(
 
 You can also assign a range in the bar by assiging the data_key in the `rx.bar` to a list with two elements, i.e. here a range of two temperatures for each date.
 
-```reflex
+```python eval
 docgraphing(
   range_bar_chart, 
   comp = eval(range_bar_chart),

--- a/docs/library/graphing/brush.md
+++ b/docs/library/graphing/brush.md
@@ -1,4 +1,4 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo, docgraphing
 
@@ -61,11 +61,12 @@ brush_example = """rx.bar_chart(
                 rx.x_axis(data_key="name"), 
                 rx.y_axis(),
                 data=data)"""
----
+```
+
 The brush component allows us to view charts that have a large number of data points. So to view and analyze them efficiently, there is a slider down them that helps the viewer to select some data points that the viewer needs to be displayed.
 
 
-```reflex
+```python eval
 docgraphing(
   brush_example, 
   comp = eval(brush_example),

--- a/docs/library/graphing/cartesian_axis_grid.md
+++ b/docs/library/graphing/cartesian_axis_grid.md
@@ -1,4 +1,4 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo, docgraphing
 
@@ -136,11 +136,11 @@ composed_chart_example = """rx.composed_chart(
                 rx.cartesian_grid(stroke_dasharray="3 3"),
                 rx.graphing_tooltip(),
                 data=data)"""
----
+```
 
 A cartesian axis adds in reference axes to the cartesian graphs.
 
-```reflex
+```python eval
 docgraphing(
   composed_chart_example, 
   comp = eval(composed_chart_example),

--- a/docs/library/graphing/composed_chart.md
+++ b/docs/library/graphing/composed_chart.md
@@ -1,4 +1,4 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo, docgraphing
 
@@ -136,13 +136,13 @@ composed_chart_example = """rx.composed_chart(
                 rx.cartesian_grid(stroke_dasharray="3 3"),
                 rx.graphing_tooltip(),
                 data=data)"""
----
+```
 
 
 A `composed_chart` is a chart that is composed of multiple charts. The charts are placed on top of each other. The charts are placed in the order they are given in the `composed_chart` function.
 
 
-```reflex
+```python eval
 docgraphing(
   composed_chart_example, 
   comp = eval(composed_chart_example),

--- a/docs/library/graphing/error_bar.md
+++ b/docs/library/graphing/error_bar.md
@@ -1,4 +1,4 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo, docgraphing
 
@@ -89,10 +89,11 @@ scatter_chart_simple_example = """rx.scatter_chart(
                 rx.graphing_tooltip(),
                 rx.legend(),
                 )"""
----
+```
+
 An error bar is a line through a point on a graph, parallel to one of the axes, which represents the uncertainty or variation of the corresponding coordinate of the point.
 
-```reflex
+```python eval
 docgraphing(scatter_chart_simple_example, comp=eval(scatter_chart_simple_example), data =  "data=" + str(data))
 ```
 

--- a/docs/library/graphing/funnel_chart.md
+++ b/docs/library/graphing/funnel_chart.md
@@ -1,4 +1,4 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo, docgraphing
 
@@ -39,12 +39,12 @@ funnel_chart_example = """rx.funnel_chart(
                 rx.graphing_tooltip(), 
                 width=730, 
                 height=250)"""
----
+```
 
 A funnel chart is a graphical representation used to visualize how data moves through a process. In a funnel chart, the dependent variable’s value diminishes in the subsequent stages of the process. It can be used to demonstrate the flow of users through for example a business or sales process.
 
 
-```reflex
+```python eval
 docgraphing(
   funnel_chart_example, 
   comp = eval(funnel_chart_example),

--- a/docs/library/graphing/label.md
+++ b/docs/library/graphing/label.md
@@ -1,4 +1,4 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo, docgraphing
 
@@ -70,11 +70,11 @@ brush_example = """rx.bar_chart(
                 margin={"left": 10, "right": 0, "top": 20, "bottom": 10},
 
                 data=data)"""
----
+```
 
 `rx.label`and `rx.label_list` add in labels to the graphs. `rx.label_list` takes in a `data_key` where we define the data column to plot.
 
-```reflex
+```python eval
 docgraphing(
   brush_example, 
   comp = eval(brush_example),

--- a/docs/library/graphing/legend.md
+++ b/docs/library/graphing/legend.md
@@ -1,4 +1,4 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo, docgraphing
 
@@ -137,12 +137,12 @@ composed_chart_example = """rx.composed_chart(
                 rx.graphing_tooltip(),
                 rx.legend(),
                 data=data)"""
----
+```
 
 
 A legend tells what each plot represents. Just like on a map, the legend helps the reader understand what they are looking at. For a line graph for example it tells us what each line represents.
 
-```reflex
+```python eval
 docgraphing(
   composed_chart_example, 
   comp = eval(composed_chart_example),

--- a/docs/library/graphing/line_chart.md
+++ b/docs/library/graphing/line_chart.md
@@ -1,4 +1,4 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo, docgraphing
 
@@ -75,19 +75,19 @@ line_chart_complex_example = """rx.line_chart(
                 rx.legend(),
                 data=data
                 )"""
----
+```
 
 A line chart is a type of chart used to show information that changes over time. Line charts are created by plotting a series of several points and connecting them with a straight line.
 
 For a line chart we must define an `rx.line()` component for each set of values we wish to plot. Each `rx.line()` component has a `data_key` which clearly states which variable in our data we are tracking. In this simple example we plot `pv` and `uv` as separate lines against the `name` column which we set as the `data_key` in `rx.x_axis`.
 
-```reflex
+```python eval
 docgraphing(line_chart_simple_example, comp=eval(line_chart_simple_example), data =  "data=" + str(data))
 ```
 
 Our second example uses exactly the same data as our first example, except now we add some extra features to our line graphs. We add a `type_` prop to `rx.line` to style the lines differently. In addition, we add an `rx.cartesian_grid` to get a grid in the background, an `rx.legend` to give us a legend for our graphs and an `rx.graphing_tooltip` to add a box with text that appears when you pause the mouse pointer on an element in the graph.
 
-```reflex
+```python eval
 docgraphing(line_chart_complex_example, comp=eval(line_chart_complex_example), data =  "data=" + str(data))
 ```
 

--- a/docs/library/graphing/pie_chart.md
+++ b/docs/library/graphing/pie_chart.md
@@ -1,4 +1,4 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo, docgraphing
 
@@ -89,17 +89,18 @@ pie_chart_complex_example = """rx.pie_chart(
                     rx.graphing_tooltip(),
                     )"""
 
----
+```
+
 A pie chart is a circular statistical graphic which is divided into slices to illustrate numerical proportion.
 
 For a pie chart we must define an `rx.pie()` component for each set of values we wish to plot. Each `rx.pie()` component has a `data`, a `data_key` and a `name_key` which clearly states which data and which variables in our data we are tracking. In this simple example we plot `value` column as our `data_key` against the `name` column which we set as our `name_key`.
 
-```reflex
+```python eval
 docgraphing(pie_chart_simple_example, comp=eval(pie_chart_simple_example),  data =  "data01=" + str(data01))
 ```
 
 We can also add two pies on one chart by using two `rx.pie` components.
 
-```reflex
+```python eval
 docgraphing(pie_chart_complex_example, comp=eval(pie_chart_complex_example),  data =  "data01=" + str(data01) + "&data02=" + str(data02))
 ```

--- a/docs/library/graphing/radar_chart.md
+++ b/docs/library/graphing/radar_chart.md
@@ -1,4 +1,4 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo, docgraphing
 
@@ -70,19 +70,20 @@ radar_chart_complex_example = """rx.radar_chart(
                     data=data
                     )"""
 
----
+```
+
 A radar chart shows multivariate data of three or more quantitative variables mapped onto an axis. 
 
 For a radar chart we must define an `rx.radar()` component for each set of values we wish to plot. Each `rx.radar()` component has a `data_key` which clearly states which variable in our data we are plotting. In this simple example we plot the `A` column of our data against the `subject` column which we set as the `data_key` in `rx.polar_angle_axis`. 
 
 
-```reflex
+```python eval
 docgraphing(radar_chart_simple_example, comp=eval(radar_chart_simple_example),  data =  "data=" + str(data))
 ```
 
 We can also add two radars on one chart by using two `rx.radar` components.
 
-```reflex
+```python eval
 docgraphing(radar_chart_complex_example, comp=eval(radar_chart_complex_example),  data =  "data=" + str(data))
 ```
 

--- a/docs/library/graphing/reference.md
+++ b/docs/library/graphing/reference.md
@@ -1,4 +1,4 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo, docgraphing
 
@@ -86,9 +86,9 @@ scatter_chart_simple_example = """rx.scatter_chart(
                 rx.y_axis(data_key="y", name="y", type_="number"),
                 rx.graphing_tooltip(),
                 )"""
----
+```
 
-```reflex
+```python eval
 docgraphing(scatter_chart_simple_example, comp=eval(scatter_chart_simple_example), data =  "data=" + str(data))
 ```
 

--- a/docs/library/graphing/scatter_chart.md
+++ b/docs/library/graphing/scatter_chart.md
@@ -1,4 +1,4 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo, docgraphing
 
@@ -93,20 +93,21 @@ scatter_chart_simple_complex = """rx.scatter_chart(
                 rx.z_axis(data_key="z", range=[60, 400], name="score"),
                 rx.legend(),
                 rx.graphing_tooltip(),
-                margin={"top": 20, "right": 20}
+                
                 )"""
 
----
+```
+
 A scatter chart always has two value axes to show one set of numerical data along a horizontal (value) axis and another set of numerical values along a vertical (value) axis. The chart displays points at the intersection of an x and y numerical value, combining these values into single data points.
 
 For a scatter chart we must define an `rx.scatter()` component for each set of values we wish to plot. Each `rx.scatter()` component has a `data` prop which clearly states which data source we plot. We also must define `rx.x_axis()` and `rx.y_axis()` so that the graph knows what data to plot on each axis.
 
-```reflex
+```python eval
 docgraphing(scatter_chart_simple_example, comp=eval(scatter_chart_simple_example), data =  "data01=" + str(data01))
 ```
 
 We can also add two scatters on one chart by using two `rx.scatter()` components, and we can define an `rx.z_axis()` which represents a third column of data and is represented by the size of the dots in the scatter plot.
 
-```reflex
+```python eval
 docgraphing(scatter_chart_simple_complex, comp=eval(scatter_chart_simple_complex), data =  "data01=" + str(data01) + "&data02=" + str(data02))
 ```

--- a/docs/library/graphing/tooltip.md
+++ b/docs/library/graphing/tooltip.md
@@ -1,4 +1,4 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo, docgraphing
 
@@ -136,11 +136,11 @@ composed_chart_example = """rx.composed_chart(
                 rx.cartesian_grid(stroke_dasharray="3 3"),
                 rx.graphing_tooltip(),
                 data=data)"""
----
+```
 
 Tooltips are the little boxes that pop up when you hover over something. Tooltips are always attached to something, like a dot on a scatter chart, or a bar on a bar chart.
 
-```reflex
+```python eval
 docgraphing(
   composed_chart_example, 
   comp = eval(composed_chart_example),

--- a/docs/library/graphing/treemap.md
+++ b/docs/library/graphing/treemap.md
@@ -1,4 +1,4 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo, docgraphing
 
@@ -353,12 +353,12 @@ treemap_example = """rx.treemap(
                 stroke="#fff",
                 fill="#8884d8")"""
 
----
+```
 
 Treemaps display hierarchical (tree-structured) data as a set of nested rectangles. Each branch of the tree is given a rectangle, which is then tiled with smaller rectangles representing sub-branches. A leaf node's rectangle has an area proportional to a specified dimension of the data.
 
 
-```reflex
+```python eval
 docgraphing(treemap_example, comp=eval(treemap_example), data =  "data=" + str(data))
 ```
 

--- a/docs/library/layout/aspect_ratio.md
+++ b/docs/library/layout/aspect_ratio.md
@@ -1,22 +1,21 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo
-
-image_example = (
-    """rx.box(element="iframe", src="https://bit.ly/naruto-sage", border_color="red")"""
-)
-
-aspect_ratio_example = f"""rx.aspect_ratio({image_example}, ratio=4/3)"""
-
----
+```
 
 Preserve the ratio of the components contained within a region.
 
-```reflex
-docdemo(image_example)
+```python exec
+image_example = rx.box(element="iframe", src="https://bit.ly/naruto-sage", border_color="red")
+print(image_example)
 ```
 
-```reflex
-docdemo(aspect_ratio_example)
+```python eval
+docdemo("""(rx.box(element="iframe", src="https://bit.ly/naruto-sage", border_color="red")
+)""")
+```
+
+```python eval
+docdemo("""rx.aspect_ratio(image_example, ratio=4/3)""", comp=rx.aspect_ratio(image_example, ratio=4/3))
 ```
 

--- a/docs/library/layout/box.md
+++ b/docs/library/layout/box.md
@@ -1,47 +1,40 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo
+```
 
-colorful_boxes_example = """rx.vstack(
+Box is a generic container component that can be used to group other components.
+
+```python eval
+docdemo("""rx.vstack(
     rx.box("Example", bg="yellow", border_radius="sm", width="20%"),
     rx.box("Example", bg="orange", border_radius="md", width="40%"),
     rx.box("Example", bg="red", border_radius="md", width="60%"),
     rx.box("Example", bg="lightblue", border_radius="lg", width="80%"),
     rx.box("Example", bg="lightgreen", border_radius="xl", width="100%"),
     width="100%",
-)"""
+)""")
+```
 
-button_box_example = """rx.box(
+Below is an example of how a box component can contain other components.
+
+```python eval
+docdemo("""rx.box(
     rx.button("Click Me"),
     bg="lightgreen",
     border_radius="15px",
     border_color="green",
     border_width="thick",
     padding=5,
-)"""
-
-iframe_box_example = """rx.box(
-    element= "iframe",
-    src="https://www.youtube.com/embed/9bZkp7q19f0",
-    width = "100%",
-)"""
-
----
-
-Box is a generic container component that can be used to group other components.
-
-```reflex
-docdemo(colorful_boxes_example)
-```
-
-Below is an example of how a box component can contain other components.
-
-```reflex
-docdemo(button_box_example)
+)""")
 ```
 
 Box can also compose videos and iframe elements.
 
-```reflex
-docdemo(iframe_box_example)
+```python eval
+docdemo("""rx.box(
+    element= "iframe",
+    src="https://www.youtube.com/embed/9bZkp7q19f0",
+    width = "100%",
+)""")
 ```

--- a/docs/library/layout/card.md
+++ b/docs/library/layout/card.md
@@ -1,19 +1,16 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo
-
-card_example = """rx.card(
-    rx.text("Body of the Card Component"), 
-    header=rx.heading("Header", size="lg"), 
-    footer=rx.heading("Footer",size="sm"),
-)"""
-
----
+```
 
 Card is a flexible component used to group and display content in a clear and concise format.
 
-```reflex
-docdemo(card_example)
+```python eval
+docdemo("""rx.card(
+    rx.text("Body of the Card Component"), 
+    header=rx.heading("Header", size="lg"), 
+    footer=rx.heading("Footer",size="sm"),
+)""")
 ```
 
 You can pass a header with `header=` and/or a footer with `footer=`.

--- a/docs/library/layout/center.md
+++ b/docs/library/layout/center.md
@@ -1,15 +1,23 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo
+```
 
-hello_world_center_example = """rx.center(
+Center, Square, and Circle are components that center its children within itself.
+
+```python eval
+docdemo("""rx.center(
     rx.text("Hello World!"),
     border_radius="15px",
     border_width="thick",
     width="50%",
-)
-"""
-circle_square_example = """rx.hstack(
+)""")
+```
+
+Below are examples of circle and square.
+
+```python eval
+docdemo("""rx.hstack(
     rx.square(
         rx.vstack(rx.text("Square")),
         border_width="thick",
@@ -23,19 +31,6 @@ circle_square_example = """rx.hstack(
         padding="1em",
     ),
     spacing="2em",
-)"""
-
----
-
-Center, Square, and Circle are components that center its children within itself.
-
-```reflex
-docdemo(hello_world_center_example)
-```
-
-Below are examples of circle and square.
-
-```reflex
-docdemo(circle_square_example)
+)""")
 ```
 

--- a/docs/library/layout/container.md
+++ b/docs/library/layout/container.md
@@ -1,17 +1,14 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo
-
-container_example = """rx.container(
-    rx.box("Example", bg="blue", color="white", width="50%"),
-    center_content=True,
-    bg="lightblue",
-)"""
-
----
+```
 
 Containers are used to constrain a content's width to the current breakpoint, while keeping it fluid.
 
-```reflex
-docdemo(container_example)
+```python eval
+docdemo("""rx.container(
+    rx.box("Example", bg="blue", color="white", width="50%"),
+    center_content=True,
+    bg="lightblue",
+)""")
 ```

--- a/docs/library/layout/flex.md
+++ b/docs/library/layout/flex.md
@@ -1,32 +1,27 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo
+```
 
-flex_example = """rx.flex(
+Flexbox is a layout model that allows elements to align and distribute space within a container. Using flexible widths and heights, elements can be aligned to fill a space or distribute space between elements, which makes it a great tool to use for responsive design systems.
+
+```python eval
+docdemo("""rx.flex(
     rx.center("Center", bg="lightblue"),
     rx.square("Square", bg="lightgreen", padding=10),
     rx.box("Box", bg="salmon", width="150px"),
-)"""
+)""")
+```
 
-flex_example_with_spacer = """rx.flex(
+Combining flex with spacer allows for stackable and responsive components.
+
+```python eval
+docdemo("""rx.flex(
     rx.center("Center", bg="lightblue"),
     rx.spacer(),
     rx.square("Square", bg="lightgreen", padding=10),
     rx.spacer(),
     rx.box("Box", bg="salmon", width="150px"),
     width = "100%",
-)"""
-
----
-
-Flexbox is a layout model that allows elements to align and distribute space within a container. Using flexible widths and heights, elements can be aligned to fill a space or distribute space between elements, which makes it a great tool to use for responsive design systems.
-
-```reflex
-docdemo(flex_example)
-```
-
-Combining flex with spacer allows for stackable and responsive components.
-
-```reflex
-docdemo(flex_example_with_spacer)
+)""")
 ```

--- a/docs/library/layout/fragment.md
+++ b/docs/library/layout/fragment.md
@@ -1,20 +1,17 @@
----
+```python exec
 import reflex as rx
 from pcweb import constants
 from pcweb.templates.docpage import docdemo
-
-fragment_example = """rx.fragment(
-    rx.text("Component1"), 
-    rx.text("Component2")
-)"""
-
----
+```
 
 A Fragment is a Component that allow you to group multiple Components without a wrapper node.
 
 Refer to the React docs at [React/Fragment]({constants.FRAGMENT_COMPONENT_INFO_URL}) for more information on its use-case.
 
-```reflex
-docdemo(fragment_example)
+```python eval
+docdemo("""rx.fragment(
+    rx.text("Component1"), 
+    rx.text("Component2")
+)""")
 ```
 

--- a/docs/library/layout/grid.md
+++ b/docs/library/layout/grid.md
@@ -1,8 +1,12 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo
+```
 
-grid_simple_example = """rx.grid(
+A primitive useful for grid layouts. Grid is Box with display, grid and it comes with helpful style shorthand. It renders a div element.
+
+```python eval
+docdemo("""rx.grid(
     rx.grid_item(row_span=1, col_span=1, bg="lightgreen"),
     rx.grid_item(row_span=1, col_span=1, bg="lightblue"),
     rx.grid_item(row_span=1, col_span=1, bg="purple"),
@@ -12,9 +16,13 @@ grid_simple_example = """rx.grid(
     h="10em",
     width="100%",
     gap=4,
-)"""
+)""")
+```
 
-grid_complex_example = """rx.grid(
+In some layouts, you may need certain grid items to span specific amount of columns or rows instead of an even distribution. To achieve this, you need to pass the col_span prop to the GridItem component to span across columns and also pass the row_span component to span across rows. You also need to specify the template_columns and template_rows.
+
+```python eval
+docdemo("""rx.grid(
     rx.grid_item(row_span=2, col_span=1, bg="lightblue"),
     rx.grid_item(col_span=2, bg="lightgreen"),
     rx.grid_item(col_span=2, bg="yellow"),
@@ -24,19 +32,6 @@ grid_complex_example = """rx.grid(
     h="200px",
     width="100%",
     gap=4,
-)"""
-
----
-
-A primitive useful for grid layouts. Grid is Box with display, grid and it comes with helpful style shorthand. It renders a div element.
-
-```reflex
-docdemo(grid_simple_example)
-```
-
-In some layouts, you may need certain grid items to span specific amount of columns or rows instead of an even distribution. To achieve this, you need to pass the col_span prop to the GridItem component to span across columns and also pass the row_span component to span across rows. You also need to specify the template_columns and template_rows.
-
-```reflex
-docdemo(grid_complex_example)
+)""")
 ```
 

--- a/docs/library/layout/responsive_grid.md
+++ b/docs/library/layout/responsive_grid.md
@@ -1,8 +1,14 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo
+```
 
-responsive_grid_example_1 = """rx.responsive_grid(
+ResponsiveGrid provides a friendly interface to create responsive grid layouts with ease. SimpleGrid composes Box so you can pass all the Box props and css grid props with addition to the ones below.
+
+Specify a fixed number of columns for the grid layout.
+
+```python eval
+docdemo("""rx.responsive_grid(
     rx.box(height="5em", width="5em", bg="lightgreen"),
     rx.box(height="5em", width="5em", bg="lightblue"),
     rx.box(height="5em", width="5em", bg="purple"),
@@ -11,9 +17,12 @@ responsive_grid_example_1 = """rx.responsive_grid(
     rx.box(height="5em", width="5em", bg="yellow"),
     columns=[3],
     spacing="4",
-)"""
+)""")
+```
 
-responsive_grid_example_2 = """rx.responsive_grid(
+
+```python eval
+docdemo("""rx.responsive_grid(
     rx.box(height="5em", width="5em", bg="lightgreen"),
     rx.box(height="5em", width="5em", bg="lightblue"),
     rx.box(height="5em", width="5em", bg="purple"),
@@ -21,19 +30,5 @@ responsive_grid_example_2 = """rx.responsive_grid(
     rx.box(height="5em", width="5em", bg="orange"),
     rx.box(height="5em", width="5em", bg="yellow"),
     columns=[1, 2, 3, 4, 5, 6],
-)"""
-
----
-
-ResponsiveGrid provides a friendly interface to create responsive grid layouts with ease. SimpleGrid composes Box so you can pass all the Box props and css grid props with addition to the ones below.
-
-Specify a fixed number of columns for the grid layout.
-
-```reflex
-docdemo(responsive_grid_example_1)
-```
-
-
-```reflex
-docdemo(responsive_grid_example_2)
+)""")
 ```

--- a/docs/library/layout/spacer.md
+++ b/docs/library/layout/spacer.md
@@ -1,21 +1,18 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo
+```
 
-spacer_example = """rx.flex(
+Creates an adjustable, empty space that can be used to tune the spacing between child elements within Flex.
+
+```python eval
+docdemo("""rx.flex(
     rx.center(rx.text("Example"), bg="lightblue"),
     rx.spacer(),
     rx.center(rx.text("Example"), bg="lightgreen"),
     rx.spacer(),
     rx.center(rx.text("Example"), bg="salmon"),
     width="100%",
-)"""
-
----
-
-Creates an adjustable, empty space that can be used to tune the spacing between child elements within Flex.
-
-```reflex
-docdemo(spacer_example)
+)""")
 ```
 

--- a/docs/library/layout/stack.md
+++ b/docs/library/layout/stack.md
@@ -1,34 +1,28 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo
+```
 
-hstack_example = """rx.hstack(
+Below are two examples the different types of stack components vstack and hstack for ordering items on a page.
+
+```python eval
+docdemo("""rx.hstack(
     rx.box("Example", bg="red", border_radius="md", width="10%"),
     rx.box("Example", bg="orange", border_radius="md", width="10%"),
     rx.box("Example", bg="yellow", border_radius="md", width="10%"),
     rx.box("Example", bg="lightblue", border_radius="md", width="10%"),
     rx.box("Example", bg="lightgreen", border_radius="md", width="60%"),
     width="100%",
-)"""
+)""")
+```
 
-vstack_example = """rx.vstack(
+```python eval
+docdemo("""rx.vstack(
     rx.box("Example", bg="red", border_radius="md", width="20%"),
     rx.box("Example", bg="orange", border_radius="md", width="40%"),
     rx.box("Example", bg="yellow", border_radius="md", width="60%"),
     rx.box("Example", bg="lightblue", border_radius="md", width="80%"),
     rx.box("Example", bg="lightgreen", border_radius="md", width="100%"),
     width="100%",
-)"""
-
----
-
-Below are two examples the different types of stack components vstack and hstack for ordering items on a page.
-
-```reflex
-docdemo(hstack_example)
+)""")
 ```
-
-```reflex
-docdemo(vstack_example)
-```
-

--- a/docs/library/layout/wrap.md
+++ b/docs/library/layout/wrap.md
@@ -1,8 +1,15 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo
+```
 
-wrap_example = """rx.wrap(
+Wrap is a layout component that adds a defined space between its children.
+
+It wraps its children automatically if there isn't enough space to fit any more in the same row. Think of it as a smarter flex-wrap with spacing support.
+
+
+```python eval
+docdemo("""rx.wrap(
     rx.wrap_item(rx.box("Example", bg="lightgreen", w="100px", h="80px")),
     rx.wrap_item(rx.box("Example", bg="lightblue", w="200px", h="80px")),
     rx.wrap_item(rx.box("Example", bg="red", w="300px", h="80px")),
@@ -10,14 +17,5 @@ wrap_example = """rx.wrap(
     width="100%",
     spacing="2em",
     align="center",
-)"""
----
-
-Wrap is a layout component that adds a defined space between its children.
-
-It wraps its children automatically if there isn't enough space to fit any more in the same row. Think of it as a smarter flex-wrap with spacing support.
-
-
-```reflex
-docdemo(wrap_example)
+)""")
 ```

--- a/docs/library/media/audio.md
+++ b/docs/library/media/audio.md
@@ -1,4 +1,4 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo
 
@@ -8,10 +8,11 @@ audio_example = """rx.audio(
     height="auto"
 )"""
 
----
+```
+
 The audio component can display an audio given an src path as an argument. This could either be a local path from the assets folder or an external link.
 
-```reflex
+```python eval
 docdemo(audio_example)
 ```
 

--- a/docs/library/media/video.md
+++ b/docs/library/media/video.md
@@ -1,4 +1,4 @@
----
+```python exec
 import reflex as rx
 from pcweb.templates.docpage import docdemo
 
@@ -8,10 +8,11 @@ video_example = """rx.video(
     height="auto"
 )"""
 
----
+```
+
 The video component can display a video given an src path as an argument. This could either be a local path from the assets folder or an external link.
 
-```reflex
+```python eval
 docdemo(video_example)
 ```
 

--- a/pcweb/pages/docs/component_lib/forms/form.py
+++ b/pcweb/pages/docs/component_lib/forms/form.py
@@ -1,6 +1,7 @@
 import reflex as rx
 from pcweb.base_state import State
-from pcweb import flexdown
+from pcweb.flexdown import component_map
+import flexdown
 
 class FormState(State):
 
@@ -11,8 +12,4 @@ class FormState(State):
 
 
 def render_form():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/forms/form.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/forms/form.md", component_map=component_map)

--- a/pcweb/pages/docs/component_lib/graphing/recharts.py
+++ b/pcweb/pages/docs/component_lib/graphing/recharts.py
@@ -1,123 +1,72 @@
 import reflex as rx
-from pcweb import flexdown
+from pcweb.flexdown import component_map
+import flexdown
 
 
 def render_areachart():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/graphing/area_chart.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/graphing/area_chart.md", component_map=component_map)
+
 
 def render_barchart():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/graphing/bar_chart.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/graphing/bar_chart.md", component_map=component_map)
+
 
 def render_composedchart():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/graphing/composed_chart.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/graphing/composed_chart.md", component_map=component_map)
+
 
 def render_funnelchart():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/graphing/funnel_chart.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/graphing/funnel_chart.md", component_map=component_map)
+
 
 def render_linechart():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/graphing/line_chart.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/graphing/line_chart.md", component_map=component_map)
+
 
 def render_piechart():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/graphing/pie_chart.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/graphing/pie_chart.md", component_map=component_map)
+
 
 def render_radarchart():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/graphing/radar_chart.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/graphing/radar_chart.md", component_map=component_map)
+
 
 def render_scatterchart():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/graphing/scatter_chart.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/graphing/scatter_chart.md", component_map=component_map)
+
 
 def render_treemap():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/graphing/treemap.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/graphing/treemap.md", component_map=component_map)
 
 
 def render_errorbar():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/graphing/error_bar.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/graphing/error_bar.md", component_map=component_map)
+
 
 def render_referenceline():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/graphing/reference.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/graphing/reference.md", component_map=component_map)
+
 
 def render_cartesianaxis():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/graphing/cartesian_axis_grid.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/graphing/cartesian_axis_grid.md", component_map=component_map)
+
 
 def render_xaxis():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/graphing/axis.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/graphing/axis.md", component_map=component_map)
+
 
 def render_brush():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/graphing/brush.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/graphing/brush.md", component_map=component_map)
+
 
 def render_legend():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/graphing/legend.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/graphing/legend.md", component_map=component_map)
+
 
 def render_label():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/graphing/label.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/graphing/label.md", component_map=component_map)
+
 
 def render_graphingtooltip():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/graphing/tooltip.md")
-    return rx.box(
-        *output,
-    )                      
+    return flexdown.render_file("docs/library/graphing/tooltip.md", component_map=component_map)
+                

--- a/pcweb/pages/docs/component_lib/layout.py
+++ b/pcweb/pages/docs/component_lib/layout.py
@@ -1,34 +1,23 @@
 import reflex as rx
 
 from pcweb.base_state import State
-from pcweb import flexdown
 from pcweb.templates.docpage import docdemo, doctext, subheader, doclink
+from pcweb.flexdown import component_map
+import flexdown
 
 
 # Layout
 
 def render_aspectratio():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/layout/aspect_ratio.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/layout/aspect_ratio.md", component_map=component_map)
 
 
 def render_box():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/layout/box.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/layout/box.md", component_map=component_map)
 
 
 def render_card():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/layout/card.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/layout/card.md", component_map=component_map)
 
 
 code51 = """rx.vstack(
@@ -113,75 +102,39 @@ def render_cond():
 
 
 def render_center():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/layout/center.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/layout/center.md", component_map=component_map)
 
 
 def render_container():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/layout/container.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/layout/container.md", component_map=component_map)
 
 
 def render_flex():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/layout/flex.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/layout/flex.md", component_map=component_map)
 
 
 def render_fragment():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/layout/fragment.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/layout/fragment.md", component_map=component_map)
 
 
 def render_grid():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/layout/grid.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/layout/grid.md", component_map=component_map)
 
 
 def render_responsivegrid():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/layout/responsive_grid.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/layout/responsive_grid.md", component_map=component_map)
 
 
 def render_spacer():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/layout/spacer.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/layout/spacer.md", component_map=component_map)
 
 
 def render_stack():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/layout/stack.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/layout/stack.md", component_map=component_map)
 
 
 def render_wrap():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/layout/wrap.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/layout/wrap.md", component_map=component_map)
 
 
 basic_foreach_state = """from typing import List

--- a/pcweb/pages/docs/component_lib/media.py
+++ b/pcweb/pages/docs/component_lib/media.py
@@ -2,8 +2,9 @@ import reflex as rx
 from reflex.components.media.icon import ICON_LIST
 
 from pcweb.base_state import State
-from pcweb import flexdown
 from pcweb.templates.docpage import docdemo, doctext, doccode, docdemobox
+from pcweb.flexdown import component_map
+import flexdown
 
 from PIL import Image
 import random
@@ -157,16 +158,8 @@ def render_image():
 
 
 def render_audio():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/media/audio.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/media/audio.md", component_map=component_map)
 
 
 def render_video():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/library/media/video.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/library/media/video.md", component_map=component_map)

--- a/pcweb/pages/docs/getting_started/installation.py
+++ b/pcweb/pages/docs/getting_started/installation.py
@@ -1,23 +1,8 @@
-import reflex as rx
-from pcweb import constants, flexdown
-from pcweb.templates.docpage import (
-    docalert,
-    doccode,
-    docheader,
-    doclink,
-    docpage,
-    doctext,
-    subheader,
-)
-
-app_name = "my_app_name"
-default_url = "http://localhost:3000"
+from pcweb.templates.docpage import docpage
+from pcweb.flexdown import component_map
+import flexdown
 
 
 @docpage()
 def installation():
-    # Get the file.
-    front_matter, output = flexdown.read("docs/getting-started/02-installation.md")
-    return rx.box(
-        *output,
-    )
+    return flexdown.render_file("docs/getting-started/02-installation.md", component_map=component_map)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ Pillow==9.5.0
 openai==0.27.8
 pyyaml==6.0.1
 reflex>=0.2.6
+flexdown==0.1.0a2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ Pillow==9.5.0
 openai==0.27.8
 pyyaml==6.0.1
 reflex>=0.2.6
-flexdown==0.1.0a3
+flexdown==0.1.0a4

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ Pillow==9.5.0
 openai==0.27.8
 pyyaml==6.0.1
 reflex>=0.2.6
-flexdown==0.1.0a2
+flexdown==0.1.0a3


### PR DESCRIPTION
Use the third party flexdown library rather than the builtin one. (Will merge in after the graphing docs are in, and we migrate the rest of the docs to this format).