### PR TITLE
fix: add import in adding-state tutorial

### DIFF
--- a/pcweb/pages/docs/tutorial/adding_state.py
+++ b/pcweb/pages/docs/tutorial/adding_state.py
@@ -82,6 +82,7 @@ class ChatappState(State):
 
 
 state1 = """# state.py
+import reflex as rx
 
 class State(rx.State):
 


### PR DESCRIPTION
# Fixes issue:
- Issue: https://github.com/reflex-dev/reflex/issues/1969 (Repo: https://github.com/reflex-dev/reflex)
- Add the missing import statement

<br>

# Changes made:
- Added ```import reflex as rx``` in the adding_state.py

<br>

# Files changed:
- **adding_state.py** (pcweb/pages/docs/tutorial/adding_state.py)

<br>

# Total changes: 1