### PR TITLE
Foreach docs fix

### DIFF
--- a/pcweb/pages/docs/component_lib/layout.py
+++ b/pcweb/pages/docs/component_lib/layout.py
@@ -161,9 +161,9 @@ basic_foreach = """rx.responsive_grid(
 
 foreach_index_state = """from typing import List
 class ForeachIndexState(State):
-    count: List[str] = ["red", "green", "blue", "yellow", "orange", "purple"]
+    color: List[str] = ["red", "green", "blue", "yellow", "orange", "purple"]
 
-def colored_box(color: str, index: int):
+def colored_box_index(color: str, index: int):
     return rx.box(
         rx.text(index),
         bg=color
@@ -172,8 +172,8 @@ def colored_box(color: str, index: int):
 exec(foreach_index_state)
 foreach_index = """rx.responsive_grid(
         rx.foreach(
-            ForeachIndexState.count,
-            lambda color, index: colored_box(color, index)
+            ForeachIndexState.color,
+            lambda color, index: colored_box_index(color, index)
         ),
         columns=[2, 4, 6],
     )


### PR DESCRIPTION
There's a bug where the first Foreach example in the docs shows the color index instead of the names. This is because The second example (`ForeachIndexState`) also defines a `colored_box` function with a different signature to that of the first example(`ForeachState`). Since the exec blocks are executed before rendered, the second `colored_box` function overrides the first. This PR renames the second `colored_box` to fix the conflict