### PR TITLE
Fix broken link to wrapping-react and missing space

### DIFF
--- a/docs/api-reference/browser_javascript.md
+++ b/docs/api-reference/browser_javascript.md
@@ -3,6 +3,7 @@ import asyncio
 import inspect
 from typing import Any
 import reflex as rx
+import pcweb.pages.docs.wrapping_react
 from pcweb.base_state import State
 from pcweb.templates.docpage import docalert, doccode, docdemobox 
 ```
@@ -39,7 +40,7 @@ These previous two methods can work in tandem to load external scripts and then
 call functions defined within them in response to user events.
 
 The following two methods are geared towards wrapping components and are
-described with examples in the [Wrapping React](/docs/advanced-guide/wrapping-react/)
+described with examples in the [Wrapping React]({pcweb.pages.docs.wrapping_react.overview.path})
 section.
 
 * `_get_hooks` and `_get_custom_code` in an `rx.Component` subclass

--- a/docs/wrapping-react/complex-example.md
+++ b/docs/wrapping-react/complex-example.md
@@ -26,7 +26,7 @@ class ReactFlowLib(Component):
         """
 ```
 
-Notice we also use the`_get_custom_code` method to import the css file that is needed for the styling of the library.
+Notice we also use the `_get_custom_code` method to import the css file that is needed for the styling of the library.
 
 ## Components 
 


### PR DESCRIPTION
Found while testing

https://pcweb-silver-wood.reflex.run/docs/api-reference/browser_javascript/