### PR TITLE
Memoize markdown components

### DIFF
--- a/pcweb/flexdown.py
+++ b/pcweb/flexdown.py
@@ -11,7 +11,6 @@ from pcweb.templates.docpage import (
     doclink2,
 )
 
-
 component_map = {
     "h1": lambda text: h1_comp(text=text),
     "h2": lambda text: h2_comp(text=text),
@@ -23,6 +22,10 @@ component_map = {
 }
 xd = flexdown.Flexdown(component_map=component_map)
 
+
+@rx.memo
+def markdown_memo(content: str) -> rx.Component:
+    return rx.markdown(content, component_map=component_map)
 
 def render_file(path):
     return xd.render_file(path)

--- a/pcweb/pages/docs/component.py
+++ b/pcweb/pages/docs/component.py
@@ -12,6 +12,7 @@ from pcweb.components.sidebar import SidebarItem
 from pcweb.pages.docs.component_lib import *
 from pcweb.templates.docpage import docheader, docpage, subheader
 from pcweb import constants, styles
+from pcweb.flexdown import markdown_memo
 
 
 class Prop(Base):
@@ -172,7 +173,7 @@ def prop_docs(prop: Prop) -> list[rx.Component]:
     return [
         rx.td(rx.code(prop.name, color="#333")),
         rx.td(rx.badge(type_, color_scheme=color, variant="solid")),
-        rx.td(rx.markdown(prop.description)),
+        rx.td(markdown_memo(content=prop.description)),
     ]
 
 
@@ -486,7 +487,7 @@ def component_docs(component):
 
     return rx.box(
         docheader(component.__name__),
-        rx.markdown(src.get_docs()),
+        markdown_memo(content=src.get_docs()),
         rx.divider(),
         *props,
         *triggers,


### PR DESCRIPTION
Speed up compilation - a lot of time was spent compiling out the same markdown components repeatedly.