### PR TITLE
Add integration test to `reflex export`

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,36 @@
+name: integration-tests
+
+env:
+  TELEMETRY_ENABLED: false
+  REFLEX_DEP: "git+https://github.com/reflex-dev/reflex@main"
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      reflex_dep:
+        description: "Reflex dependency (full specifier)"
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  reflex-web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.11' 
+      - name: Install Requirements for reflex-web and reflex
+        run: pip install '${{ github.event.inputs.reflex_dep || env.REFLEX_DEP }}' -r requirements.txt
+      - name: Init Website for reflex-web
+        run: reflex init
+      - name: Export the website
+        run: reflex export


### PR DESCRIPTION
Ensure that the changes can be compiled and exported successfully with the version of reflex in `main`. Allow specifying an alternative reflex dependency for manual runs.