### PR TITLE
Tweaks for reflex 0.3.5

### DIFF
--- a/pcweb/components/navbar.py
+++ b/pcweb/components/navbar.py
@@ -245,7 +245,7 @@ Feedback: {feedback}
     def update_category(self, tag):
         self.current_category = tag
 
-    @rx.var
+    @rx.cached_var
     def search_results(self) -> list[dict[str, dict[str, str]]]:
         """Get the search results."""
         from pcweb.tsclient import client

--- a/pcweb/flexdown.py
+++ b/pcweb/flexdown.py
@@ -2,7 +2,7 @@ import reflex as rx
 import flexdown
 
 from pcweb.templates.docpage import (
-    code_block2,
+    code_block_markdown,
     text_comp,
     h1_comp,
     h2_comp,
@@ -18,7 +18,7 @@ component_map = {
     "p": lambda text: text_comp(text=text),
     "a": doclink2,
     "code": lambda text: code_comp(text=text),
-    "codeblock": code_block2,
+    "codeblock": code_block_markdown,
 }
 xd = flexdown.Flexdown(component_map=component_map)
 

--- a/pcweb/middleware.py
+++ b/pcweb/middleware.py
@@ -2,6 +2,9 @@
 
 import reflex as rx
 
+from pcweb.components.navbar import NavbarState
+from pcweb.pages.index import IndexState
+
 
 class CloseSidebarMiddleware(rx.Middleware):
     """Middleware to make sure the sidebar closes when the page changes."""
@@ -15,5 +18,5 @@ class CloseSidebarMiddleware(rx.Middleware):
             event: The event to preprocess.
         """
         if event.name == rx.event.get_hydrate_event(state):
-            state.get_substate(["navbar_state"]).sidebar_open = False
-            state.get_substate(["index_state"]).show_c2a = True
+            state.get_substate(NavbarState.get_full_name().split(".")).sidebar_open = False
+            state.get_substate(IndexState.get_full_name().split(".")).show_c2a = True

--- a/pcweb/pages/docs/gallery.py
+++ b/pcweb/pages/docs/gallery.py
@@ -278,7 +278,7 @@ class SideBarState(State):
     def update_tag(self, name: str):
         self.chosen_tags_dict[name] = not self.chosen_tags_dict[name]
 
-    @rx.var
+    @rx.cached_var
     def true_tags(self) -> list:
         """This function returns a list of the tags selected in the UI, if no tags
         are selected then it returns all the tags"""
@@ -288,7 +288,7 @@ class SideBarState(State):
             return list(self.chosen_tags_dict)
         return list(true_keys)
 
-    @rx.var
+    @rx.cached_var
     def data_to_return(self) -> list[dict[str, str]]:
         """This function iterates over all the apps we have and if the app has one of the
         tags we have selected in true_tags then it will render this app in the UI"""

--- a/pcweb/pages/page404.py
+++ b/pcweb/pages/page404.py
@@ -8,19 +8,13 @@ from pcweb.components.footer import footer
 from pcweb.components.navbar import navbar
 
 
-class State404(State):
-    @rx.var
-    def origin_url(self) -> str:
-        return self.router_data.get("asPath", "")
-
-
 def _404():
     return rx.center(
         rx.vstack(
             rx.heading(rx.constants.Page404.TITLE),
             rx.text(
                 "Oups, the page at ",
-                rx.code(State404.origin_url),
+                rx.code(State.router.page.raw_path),
                 " doesn't exist.",
             ),
             rx.spacer(),

--- a/pcweb/templates/docpage.py
+++ b/pcweb/templates/docpage.py
@@ -42,37 +42,9 @@ def code_block(code: str, language: str):
     )
 
 
-@rx.memo
-def code_block_memo(children: str, language: str):
-    return rx.box(
-        rx.box(
-            rx.code_block(
-                language=language,
-                border_radius=styles.DOC_BORDER_RADIUS,
-                theme="light",
-                background="transparent",
-                code_tag_props={
-                    "style": {
-                        "fontFamily": "inherit",
-                    }
-                },
-            ).set(
-                special_props={
-                    rx.Var.create_safe("children={children}"),
-                }
-            ),
-            border_radius=styles.DOC_BORDER_RADIUS,
-            border="2px solid #F4F3F6",
-        ),
-        position="relative",
-        margin_bottom="1em",
-        width="100%",
-    )
-
-
-def code_block2(*_, **props):
+def code_block_markdown(*children, **props):
     language = props.get("language", "none")
-    return code_block_memo(children="", language=language)
+    return code_block(code=children[0], language=language)
 
 
 # Docpage styles.


### PR DESCRIPTION
* Use `cached_var` to reduce network overhead
* Use `get_full_name` when referencing state by string, now that the state tree has an extra root in `rx.State`
* Remove special case `code_block_memo`, now that `rx.code_block` has been updated to work transparently with markdown component_map, this extra `children={children}` special prop is no longer needed.