### PR TITLE
Remove formatting attribute from the Seed Announcement blog

### DIFF
--- a/blog/2023-08-02-seed-annoucement.md
+++ b/blog/2023-08-02-seed-annoucement.md
@@ -61,6 +61,6 @@ We will continue to grow our open-source framework to have feature parity with t
 This includes adding more complex styling methods like detailed animations and improvements to our core component library.  
 
 A more detailed roadmap of what’s coming next can be found [here](https://reflex-dev.notion.site/d1b60926ced14914bdbb42547ac84e50?v=723e0afc57294e40961d177aa691ee37).
-Stay tuned for updates on our progress!", padding_bottom="2em")
+Stay tuned for updates on our progress!
 
 -- Reflex Team


### PR DESCRIPTION
This commit fixes a regression introduced when removing `doctext` from blog posts: https://github.com/reflex-dev/reflex-web/pull/322/files#diff-a0b2b4d2e03d7b7f3867cf9ed12453198057b7e5866002c52078d3567ea24a79R64