### PR TITLE
Update hosting service docs

### DIFF
--- a/docs/hosting/deploy.md
+++ b/docs/hosting/deploy.md
@@ -3,6 +3,7 @@
 ```python exec
 import reflex as rx
 from pcweb import constants
+from pcweb.templates.docpage import doccmdoutput
 from reflex.components.radix.themes.components import *
 from reflex.components.radix.themes.layout import *
 from reflex.components.radix.themes.typography import *
@@ -24,8 +25,9 @@ callout_root(
         text("Hosting is in Alpha. Please reach out to us on "),
         link("Discord", href=constants.DISCORD_URL),
         text(" if you have an app ready to deploy and if we will give you an invitation code."),
-        color="black",
-        weight="bold"),
+        color_scheme="black",
+        weight="bold"
+    ),
     size="3",
     color_scheme="blue",
     high_contrast=True,
@@ -36,17 +38,33 @@ callout_root(
 
 Reflex’s hosting service makes it easy to deploy your apps without worrying about configuring your infrastructure.
 
-(This tutorial assumes you’ve successfully `reflex init` and `reflex run` your app)
+```python eval
+callout_root(
+    callout_icon(icon(tag="info_circled", width=18, height=18)),
+    callout_text(
+        text("This tutorial assumes you’ve successfully "),
+        code("reflex init"),
+        text(" and "),
+        code("reflex run"),
+        text(" your app"),
+        color="black",
+        weight="bold"
+    ),
+    size="3",
+    color_scheme="blue",
+    high_contrast=True,
+)
+```
 
 ### Authentication
 
-First, create or log in to your account using the following command. (Requires Reflex > `v0.3.1`)
+First, create or log in to your account using the following command. (Requires `Reflex >= v0.3.2`)
 
 ```bash
 reflex login
 ```
 
-You will be prompted to your browser where you can create an account using Github or Gmail for authentication.
+You will be prompted to your browser where you can authenticate through Github or Gmail.
 
 ```python eval
 callout_root(
@@ -85,13 +103,11 @@ Navigate to the project you want to deploy and type the following command:
 reflex deploy
 ```
 
-**Name**: choose a name that will be the start of your url, i.e. `<your-app-name>.reflex.run`. The name should only contain domain name safe characters, so no slashes, no underscores. It is also case insensitive, use all lower cases.
+**Name**: choose a name for the deployed app. This name will be part of the deployed app URL, i.e. `<your-app-name>.reflex.run`. The name should only contain domain name safe characters: no slashes, no underscores. It is also case insensitive, so simply use all lower cases.
 
-**Regions**: check the list of regions you can select from [reflex deployments regions](https://www.notion.so/reflex-deployments-regions-a066211142b945a8bc86697326994dbd?pvs=21)
+**Regions**: check the list of regions you can select from [reflex deployments regions](#reflex-deployments-regions)
 
 That’s it! You should receive some feedback on the progress of your deployment and in a few minutes your app should be up. 🎉
-
-Once your app is deployed, you will see a URL with your live site.
 
 ## Concepts
 
@@ -119,6 +135,15 @@ All the commands come with help manual. Type `--help` to see it, for example, `r
 4. Cont’d from 3: if the validation fails, the CLI shows 1) “**Session expired**” 2) “**User is banned**” 3) “**Access denied**” (for other cases we have no need to distinguish a bad token or just that user needs to re-authenticate) and CLI  will be opening the browser for re-authentication.
 5. If for any reason, there is no cached token on user machine, but the user session is still active on the browser, the hosting service login page will skip the step of redirecting to OAuth provider and show the same page described above in step 2.
 
+```python eval
+doccmdoutput(
+    command="reflex login",
+    output="""Opening https://control-plane.reflex.run ...
+Successfully logged in.
+""",
+)
+```
+
 #### reflex logout
 
 1. User types this command, if no token is cached, CLI shows “**Login info not found**”
@@ -138,18 +163,130 @@ Summary
 6. **Example 1** shows the sequences of a successful deployment.
 7. The deploy command by default interacts with the user and prompts for information. To provide all the settings for your app in a one shot without this interaction, use the `--no-interactive` flag. Type `reflex deploy --help` to see the help command for explanation on each flag. There is an example below: example 2. The deploy sequences are the same regardless the command is interactive or not. Example 2 skips the deploy sequences.
 
+```python eval
+doccmdoutput(
+    command="reflex deploy",
+    output="""Name of deployment (todo-blue-ocean): todo
+Region to deploy to (sjc): lax
+Environment variables ...
+  Env name (enter to skip):
+No envs added. Continuing ...
+-------------------------- Compiling production app and preparing for export. -------------------
+Compiling:  ---------------------------------------- 100% 2/2 0:00:00
+Creating Production Build:  ---------------------------------------- 100% 9/9 0:00:08
+Zipping Frontend: --------------------------------------- 100% 19/19 0:00:00
+Zipping Backend: ---------------------------------------- 100% 4/4 0:00:00
+Uploading code ...
+Deployment will start shortly.
+Waiting for the new deployment to come up
+Backend is up
+frontend is up
+Your site [ todo ] at ['lax'] is up: https://todo.reflex.run
+""",
+)
+```
+
+The non-interactive deploy command requires user to provide all the required information, such as the app name of your choice, the regions to deploy to, environmental variables if you have them.
+
+```bash
+reflex deploy --no-interactive -k todo -r sjc -r sea --env OPENAI_API_KEY=YOU-KEY-NO-EXTRA-QUOTES --env DB_URL=YOUR-EXTERNAL-DB-URI --env KEY3=THATS-ALOTOF-KEYS
+```
+
 #### reflex deployments list
 
 List all your deployments.
 
+```python eval
+doccmdoutput(
+    command="reflex deployments list",
+    output="""key                           regions  app_name              reflex_version       cpus     memory_mb  url                                         envs
+----------------------------  -------  --------------------  ----------------  -------   -----------  ------------------------------------------  ---------
+webui-navy-star               ['sjc']  webui                 0.3.7                   1          1024  https://webui-navy-star.reflex.run          ['OPENAI_API_KEY']
+chatroom-teal-ocean           ['ewr']  chatroom              0.3.2                   1          1024  https://chatroom-teal-ocean.reflex.run      []
+sales-navy-moon               ['phx']  sales                 0.3.4                   1          1024  https://sales-navy-moon.reflex.run          []
+simple-background-tasks       ['yul']  lorem_stream          0.3.7                   1          1024  https://simple-background-tasks.reflex.run  []
+snakegame                     ['sjc']  snakegame             0.3.3                   1          1024  https://snakegame.reflex.run                []
+basic-crud-navy-apple         ['dfw']  basic_crud            0.3.8                   1          1024  https://basic-crud-navy-apple.reflex.run    []
+""",
+)
+```
+
 #### reflex deployments status `app-name`
+
+Get the status of a specific app.
+
+```python eval
+doccmdoutput(
+    command="reflex deployments status clock-gray-piano",
+    output="""Getting status for [ clock-gray-piano ] ...
+
+backend_url                               reachable    updated_at
+----------------------------------------  -----------  ------------
+https://rxh-dev-clock-gray-piano.fly.dev  False        N/A
+
+
+frontend_url                                 reachable    updated_at
+-------------------------------------------  -----------  -----------------------
+https://clock-gray-piano.dev.reflexcorp.run  True         2023-10-13 15:23:07 PDT
+""",
+)
+```
 
 #### reflex deployments logs `app-name`
 
+Get the logs from a specified deployment.
+
+```python eval
+doccmdoutput(
+    command="reflex deployments logs todo",
+    output="""Note: there is a few seconds delay for logs to be available.
+2023-10-13 22:18:39.696028 | rxh-dev-todo | info | Pulling container image registry.fly.io/rxh-dev-todo:depot-1697235471
+2023-10-13 22:18:41.462929 | rxh-dev-todo | info | Pulling Gcontainer image registry.fly.io/rxh-dev-todo@sha256:60b7b531e99e037f2fb496b3e05893ee28f93a454ee618bda89a531a547c4002
+2023-10-13 22:18:45.963840 | rxh-dev-todo | info | Successfully prepared image registry.fly.io/rxh-dev-todo@sha256:60b7b531e99e037f2fb496b3e05893ee28f93a454ee618bda89a531a547c4002 (4.500906837s)
+2023-10-13 22:18:46.134860 | rxh-dev-todo | info | Successfully prepared image registry.fly.io/rxh-dev-todo:depot-1697235471 (6.438815793s)
+2023-10-13 22:18:46.210583 | rxh-dev-todo | info | Configuring firecracker
+2023-10-13 22:18:46.434645 | rxh-dev-todo | info | [    0.042971] Spectre V2 : WARNING: Unprivileged eBPF is enabled with eIBRS on, data leaks possible via Spectre v2 BHB attacks!
+2023-10-13 22:18:46.477693 | rxh-dev-todo | info | [    0.054250] PCI: Fatal: No config space access function found
+2023-10-13 22:18:46.664016 | rxh-dev-todo | info | Configuring firecracker
+""",
+)
+```
+
 #### reflex deployments build-logs `app-name`
+
+Get the logs of the hosting service deploying the app.
+
+```python eval
+doccmdoutput(
+    command="reflex deployments build-logs webcam-demo",
+    output="""Note: there is a few seconds delay for logs to be available.
+2024-01-08 11:02:46.109785 PST | fly-controller-prod | #8 extracting sha256:bd9ddc54bea929a22b334e73e026d4136e5b73f5cc29942896c72e4ece69b13d 0.0s done | None | None
+2024-01-08 11:02:46.109811 PST | fly-controller-prod | #8 DONE 5.3s | None | None
+2024-01-08 11:02:46.109834 PST | fly-controller-prod |  | None | None
+2024-01-08 11:02:46.109859 PST | fly-controller-prod | #8 [1/4] FROM public.ecr.aws/p3v4g4o2/reflex-hosting-base:v0.1.8-py3.11@sha256:9e8569507f349d78d41a86e1eb29a15ebc9dece487816875bbc874f69dcf7ecf | None | None
+...
+...
+2024-01-08 11:02:50.913748 PST | fly-controller-prod | #11 [4/4] RUN . /home/reflexuser/venv/bin/activate && pip install --no-color --no-cache-dir -q -r /home/reflexuser/app/requirements.txt reflex==0.3.4 | None | None
+...
+...
+2024-01-08 11:03:07.430922 PST | fly-controller-prod | #12 pushing layer sha256:d9212ef47485c9f363f105a05657936394354038a5ae5ce03c6025f7f8d2d425 3.5s done | None | None
+2024-01-08 11:03:07.881471 PST | fly-controller-prod | #12 pushing layer sha256:ee46d14ae1959b0cacda828e5c4c1debe32c9c4c5139fb670cde66975a70c019 3.9s done | None | None
+...
+2024-01-08 11:03:13.943166 PST | fly-controller-prod | Built backend image | None | None
+2024-01-08 11:03:13.943174 PST | fly-controller-prod | Deploying backend image... | None | None
+2024-01-08 11:03:13.943311 PST | fly-controller-prod | Running sys_run | None | None
+...
+2024-01-08 11:03:31.005887 PST | fly-controller-prod | Checking for valid image digest to be deployed to machines... | None | None
+2024-01-08 11:03:31.005893 PST | fly-controller-prod | Running sys_run | None | None
+2024-01-08 11:03:32.411762 PST | fly-controller-prod | Backend updated! | None | None
+2024-01-08 11:03:32.481276 PST | fly-controller-prod | Deploy success (backend) | None | None
+""",
+)
+```
 
 #### reflex deployments delete `app-name`
 
+Delete a specified deployment.
 
 ### Public Commands
 

--- a/docs/hosting/deploy.md
+++ b/docs/hosting/deploy.md
@@ -13,8 +13,52 @@ So far, we've been running our apps locally on our own machines.
 But what if we want to share our apps with the world?  This is where
 deployment comes in.
 
-## Reflex Deploy
+## Quick Start
+
+Reflex’s hosting service makes it easy to deploy your apps without worrying about configuring your infrastructure.
+
+(This tutorial assumes you’ve successfully `reflex init` and `reflex run` your app)
+
+### Authentication
+
+First, create or log in to your account using the following command. (Requires Reflex > v0.3.1)
+
+```bash
+reflex login
+```
+
+You will be prompted to your browser where you can create an account using Github or Gmail for authentication.
+
+```python eval
+rx.alert(
+    rx.alert_icon(),
+    rx.alert_description("You will need an invitation code! Contact us on Discord if you have an app ready to deploy, and we will give you a code."
+    ),
+    status="info",
+    width="100%",
+    margin_bottom="1rem",
+)
+```
+
+### Deployment
+
+Once you have successfully logged in to your account, you can deploy your apps.
+
+TODO: style the sentence below.
+Make sure you include a requirements.txt with all your dependencies!
+
+Navigate to the project you want to deploy and type the following command:
+
+```bash
+reflex deploy
+```
+
+**Name**: choose a name that will be the start of your url, i.e. `<your-app-name>.reflex.run`. The name should only contain domain name safe characters, so no slashes, no underscores. It is also case insensitive, use all lower cases.
+
+**Regions**: check the list of regions you can select from [reflex deployments regions](https://www.notion.so/reflex-deployments-regions-a066211142b945a8bc86697326994dbd?pvs=21)
+
+That’s it! You should receive some feedback on the progress of your deployment and in a few minutes your app should be up. 🎉
+
+Once your app is deployed, you will see a URL with your live site.
 
 Please follow the hosting guide here to deploy your app **(invitation code needed)**: [Reflex Hosting](https://reflex-dev.notion.site/Reflex-Hosting-Documentation-57a4dd55d6234858bbae0be75be79ce7?pvs=4)
-
-

--- a/docs/hosting/deploy.md
+++ b/docs/hosting/deploy.md
@@ -13,6 +13,10 @@ So far, we've been running our apps locally on our own machines.
 But what if we want to share our apps with the world?  This is where
 the hosting service comes in.
 
+```md alert info
+Hosting is in Alpha. Please reach out to us on Discord if you are ready to deploy and we will give you an invitation code.
+```
+
 ```python eval
 callout_root(
     callout_icon(icon(tag="info_circled", width=18, height=18)),
@@ -33,6 +37,10 @@ callout_root(
 
 Reflex’s hosting service makes it easy to deploy your apps without worrying about configuring the infrastructure.
 
+```md alert info
+This tutorial assumes you’ve successfully `reflex init` and `reflex run` your app.
+```
+
 ```python eval
 callout_root(
     callout_icon(icon(tag="info_circled", width=18, height=18)),
@@ -52,6 +60,10 @@ callout_root(
 ```
 
 ### Authentication
+
+```md alert info
+Hosting service requires `reflex>=0.3.2`.
+```
 
 ```python eval
 callout_root(
@@ -76,6 +88,10 @@ reflex login
 
 You will be prompted to your browser where you can authenticate through Github or Gmail.
 
+```md alert info
+You will need an invitation code! Contact us on Discord if you have an app ready to deploy, and we will give you a code.
+```
+
 ```python eval
 callout_root(
     callout_icon(icon(tag="lock_open_2", width=18, height=18)),
@@ -95,6 +111,10 @@ callout_root(
 ### Deployment
 
 Once you have successfully authenticated, you can deploy your apps.
+
+```md alert warning
+Make sure you have a `requirements.txt`  file at the top level app directory that contains all your python dependencies!
+```
 
 ```python eval
 callout_root(
@@ -126,6 +146,10 @@ The command is by default interactive. It asks you a few questions for informati
 **Envs**: `Envs` are environment variables. You might not have used them at all in your app. In that case, press `Enter` to skip. More on the environment variables in the later section [Environment Variables](#environment-variables).
 
 That’s it! You should receive some feedback on the progress of your deployment and in a few minutes your app should be up. 🎉
+
+```md alert info
+Once your code is uploaded, the hosting service will start the deployment. Exiting from the command from that point on **does not** affect the deployment process. The command prints a message when you can close the command without affecting the deployment.
+```
 
 ```python eval
 callout_root(

--- a/docs/hosting/deploy.md
+++ b/docs/hosting/deploy.md
@@ -9,7 +9,7 @@ from reflex.components.radix.themes.layout import *
 from reflex.components.radix.themes.typography import *
 ```
 
-So far, we've been running our apps locally on our own machines.
+So far, we have been running our apps locally on our own machines.
 But what if we want to share our apps with the world?  This is where
 the hosting service comes in.
 
@@ -22,7 +22,7 @@ Hosting is in Alpha. Please reach out to us on Discord if you are ready to deplo
 Reflex’s hosting service makes it easy to deploy your apps without worrying about configuring the infrastructure.
 
 ```md alert info
-This tutorial assumes you’ve successfully `reflex init` and `reflex run` your app.
+This tutorial assumes you have successfully `reflex init` and `reflex run` your app.
 ```
 
 ### Authentication
@@ -31,21 +31,17 @@ This tutorial assumes you’ve successfully `reflex init` and `reflex run` your 
 Hosting service requires `reflex>=0.3.2`.
 ```
 
-First, create or log in to your account using the following command.
+First, create an account or log into it using the following command.
 
 ```bash
 reflex login
 ```
 
-You will be prompted to your browser where you can authenticate through Github or Gmail.
-
-```md alert info
-You will need an invitation code! Contact us on Discord if you have an app ready to deploy, and we will give you a code.
-```
+You will be redirected to your browser where you can authenticate through Github or Gmail.
 
 ### Deployment
 
-Once you have successfully authenticated, you can deploy your apps.
+Once you have successfully authenticated, you can start deploying your apps.
 
 ```md alert warning
 Make sure you have a `requirements.txt`  file at the top level app directory that contains all your python dependencies!
@@ -68,7 +64,7 @@ The command is by default interactive. It asks you a few questions for informati
 That’s it! You should receive some feedback on the progress of your deployment and in a few minutes your app should be up. 🎉
 
 ```md alert info
-Once your code is uploaded, the hosting service will start the deployment. Exiting from the command from that point on **does not** affect the deployment process. The command prints a message when you can close the command without affecting the deployment.
+Once your code is uploaded, the hosting service will start the deployment. After a complete upload, exiting from the command **does not** affect the deployment process. The command prints a message when you can safely close it without affecting the deployment.
 ```
 
 ## Concepts
@@ -79,11 +75,11 @@ To be able to deploy your app, we ask that you prepare a `requirements.txt` file
 
 ### Environment Variables
 
-When deploying to Reflex's hosting service, the command prompt asks if you want to add any environment variables. These are encrypted and safely stored. We do not show the values of them in any CLI commands, only their names (or keys). We recommend that backend API keys or secrets are entered as `envs`. Make sure to enter the `Environment Variables` without any quotation marks.
+When deploying to Reflex's hosting service, the command prompt asks if you want to add any environment variables. These are encrypted and safely stored. We recommend that backend API keys or secrets are entered as `envs`. Make sure to enter the `envs` without any quotation marks.
 
-However, if your app intentionally prints the values of these variables, the logs returned still contain the printed values. At the moment, the logs are not censored against anything resembling secrets. Only the app owner and Reflex team admins can access these logs.
+The environment variables are key value pairs. We do not show the values of them in any CLI commands, only their names (or keys). However, if your app intentionally prints the values of these variables, the logs returned still contain the printed values. At the moment, the logs are not censored for anything resembling secrets. Only the app owner and Reflex team admins can access these logs.
 
-The environment variables are key value pairs. You access their values by referencing their names as keys in `os.environ` in your app's backend. For example, if you set an env `ASYNC_DB_URL`, you are able to access it by `os.environ["ASYNC_DB_URL"]`. Some Python libraries automatically look for certain environment variables. For example, `OPENAI_API_KEY` for the `openai` python client. The `boto3` client credentials can be configured by setting `AWS_ACCESS_KEY_ID`,`AWS_SECRET_ACCESS_KEY`.
+You access the values of `envs` by referencing `os.environ` with their names as keys in your app's backend. For example, if you set an env `ASYNC_DB_URL`, you are able to access it by `os.environ["ASYNC_DB_URL"]`. Some Python libraries automatically look for certain environment variables. For example, `OPENAI_API_KEY` for the `openai` python client. The `boto3` client credentials can be configured by setting `AWS_ACCESS_KEY_ID`,`AWS_SECRET_ACCESS_KEY`. This information is typically available in the documentation of the Python packages you use.
 
 ### Updating Deployment
 
@@ -91,7 +87,7 @@ To redeploy or update your app, navigate to the project directory and type `refl
 
 ## Hosting CLI Commands
 
-All the `reflex` commands come with a help manual. The help manual provides additional options that may be useful. You type `--help` to see the help manual. Some commands are organized under a `subcommands` series. Here is an example below. Note that the help manual may look different depending on the version of `reflex` or the `reflex-hosting-cli`.
+All the `reflex` commands come with a help manual. The help manual lists additional command options that may be useful. You type `--help` to see the help manual. Some commands are organized under a `subcommands` series. Here is an example below. Note that the help manual may look different depending on the version of `reflex` or the `reflex-hosting-cli`.
 
 ```python eval
 doccmdoutput(
@@ -114,13 +110,13 @@ Commands:
 )
 ```
 
-`--loglevel` is another common `reflex` command option. When setting `--loglevel debug`, a command prints additional information, which can be helpful during debug.
+`--loglevel` is another common command option. When setting `--loglevel debug`, a command prints additional information, which can be helpful during debug.
 
 ### Authentication Commands
 
 #### reflex login
 
-When you type the `reflex login` command for the very first time, it opens the hosting service login page. We authenticate users through OAuth. At the moment the supported OAuth providers are Github and Gmail. You should be able to revoke such authorization on your Github and Google account settings page. We do not log into your Github or Gmail account. OAuth authorization provides us your email address and in case of Github your username handle. We use those to create an account for you. When you return, the email used in the original account creation is used to identify you as a user. If you have authenticated using different emails, those create separate accounts. To switch to another account, first log out using the `reflex logout` command. More details on the logout command are in [reflex logout](#reflex-logout) section.
+When you type the `reflex login` command for the very first time, it opens the hosting service login page in your browser. We authenticate users through OAuth. At the moment the supported OAuth providers are Github and Gmail. You should be able to revoke such authorization on your Github and Google account settings page. We do not log into your Github or Gmail account. OAuth authorization provides us your email address and in case of Github your username handle. We use those to create an account for you. The email used in the original account creation is used to identify you as a user. If you have authenticated using different emails, those create separate accounts. To switch to another account, first log out using the `reflex logout` command. More details on the logout command are in [reflex logout](#reflex-logout) section.
 
 ```python eval
 doccmdoutput(
@@ -131,19 +127,19 @@ Successfully logged in.
 )
 ```
 
-After authenticated, the browser redirects to the original hosting service page. It shows you have logged in. Now you can return to the terminal where you type the login command. It should print a message such as `Successfully logged in`.
+After authentication, the browser redirects to the original hosting service login page. It shows that you have logged in. Now you can return to the terminal where you type the login command. It should print a message such as `Successfully logged in`.
 
 Your access token is cached locally in the reflex support directory. For subsequent login commands, the cached token is validated first. If the token is still valid, the CLI command simply shows `You’re already logged in`. If the token is expired or simply not valid for any reason, the login command tries to open your browser again for web based authentication.
 
 #### reflex logout
 
-When you successfully authenticate with the hosting service, there is information cached in two different places: a file containing the access token in the reflex support folder, and cookies in your browser. The cookies include the access token, a refresh token, some unix epochs indicating when the access token expires. The logout command removes the cached information from these places.
+When you successfully authenticate with the hosting service, there is information cached in two different places: a file containing the access token in the reflex support directory, and cookies in your browser. The cookies include the access token, a refresh token, some unix epochs indicating when the access token expires. The logout command removes the cached information from these places.
 
 ### Deployment Commands
 
 #### reflex deploy
 
-This is the command to deploy a reflex app from its top level app directory. This directory contains a `rxconfig.py` where you run `reflex init` and `reflex run`. A `requirements.txt` file is required. The deploy command checks the existence of this file and also the content of it (this is available in more recent versions of `reflex-hosting-cli` such as `0.1.3`). The command prompts you for updates on the requirements when there are new packages or newer versions of packages detected in the Python environment.
+This is the command to deploy a reflex app from its top level app directory. This directory contains a `rxconfig.py` where you run `reflex init` and `reflex run`. A `requirements.txt` file is required. The deploy command checks the existence of this file and also the content of it (this is available in more recent versions of `reflex-hosting-cli` such as `0.1.3`). The command prompts you for potential updates on the requirements when there are new packages or newer versions of packages detected in your Python environment.
 
 ```python eval
 doccmdoutput(
@@ -161,16 +157,15 @@ Zipping Backend: ---------------------------------------- 100% 4/4 0:00:00
 Uploading code ...
 Deployment will start shortly.
 Waiting for the new deployment to come up
-Backend is up
-frontend is up
+...
 Your site [ todo ] at ['lax'] is up: https://todo.reflex.run
 """,
 )
 ```
 
-The deploy command is by default interactive and prompts you for information. To provide all the settings for your app in one shot without the interaction, add the `--no-interactive` option. Type `reflex deploy --help` to see the help command for explanation on each option. The deploy sequences are the same whether the command is interactive or not.
+The deploy command is by default interactive and prompts you for information. To provide all the settings for your app in one shot without the interaction, add the `--no-interactive` option. Type `reflex deploy --help` to see the help manual for explanations on each option. The deploy sequences are the same whether the command is interactive or not.
 
-The non-interactive deploy command requires you to provide all the required information, such as the app name of your choice, the regions to deploy to, environmental variables if you have them.
+The non-interactive deploy command requires you to properly all the required information, such as the app name of your choice, the regions to deploy to, environmental variables if you have them.
 
 ```bash
 reflex deploy --no-interactive -k todo -r sjc -r sea --env OPENAI_API_KEY=YOU-KEY-NO-EXTRA-QUOTES --env DB_URL=YOUR-EXTERNAL-DB-URI --env KEY3=THATS-ALOTOF-KEYS
@@ -220,7 +215,7 @@ https://clock-gray-piano.reflex.run        True         2023-10-13 15:23:07 PDT
 
 Get the logs from a specific deployment.
 
-The returned logs are the console messages. If you have `print` statements in your code, they show up in these logs. By default, the logs command return the latest 100 lines of logs and continue to stream any new lines.
+The returned logs are the messages printed to console. If you have `print` statements in your code, they show up in these logs. By default, the logs command return the latest 100 lines of logs and continue to stream any new lines.
 
 We have added more options to this command including `from` and `to` timestamps and the limit on how many lines of logs to fetch. Accepted timestamp formats include the ISO 8601 format, unix epoch and relative timestamp. A relative timestamp is some time units ago from `now`. The units are `d (day), h (hour), m (minute), s (second)`. For example, `--from 3d --to 4h` queries from 3 days ago up to 4 hours ago. For the exact syntax in the version of CLI you use, refer to the help manual.
 
@@ -273,8 +268,6 @@ doccmdoutput(
 ```
 
 The hosting service prints log messages when preparing and deploying your app. These log messages are called build logs. Build logs are useful in troubleshooting deploy failures. For example, if there is a package `numpz==1.26.3` (supposed to be `numpy`) in the `requirements.txt`, hosting service will be unable to install it. That package does not exist. We expect to find a few lines in the build logs indicating that the `pip install` command fails.
-
-During the deploy command, we print a few lines of the deploy sequence "milestones" from the build logs, such as `Backend updated!`, `Deploy success (frontend)`.
 
 #### reflex deployments delete `app-name`
 

--- a/docs/hosting/deploy.md
+++ b/docs/hosting/deploy.md
@@ -1,17 +1,36 @@
+# Reflex Hosting Service
+
 ```python exec
 import reflex as rx
+from pcweb import constants
+from reflex.components.radix.themes.components import *
+from reflex.components.radix.themes.layout import *
+from reflex.components.radix.themes.typography import *
 ```
 
-# Reflex Hosting Service
+So far, we've been running our apps locally on our own machines.
+But what if we want to share our apps with the world?  This is where
+deployment comes in.
 
 ```md alert info
 # Hosting is in Alpha
 Please reach out to us on Discord if you have an app ready to deploy and we will give you an invitation code.
 ```
 
-So far, we've been running our apps locally on our own machines.
-But what if we want to share our apps with the world?  This is where
-deployment comes in.
+```python eval
+callout_root(
+    callout_icon(icon(tag="info_circled", width=18, height=18)),
+    callout_text(
+        text("Hosting is in Alpha. Please reach out to us on "),
+        link("Discord", href=constants.DISCORD_URL),
+        text(" if you have an app ready to deploy and if we will give you an invitation code."),
+        color="black",
+        weight="bold"),
+    size="3",
+    color_scheme="blue",
+    high_contrast=True,
+)
+```
 
 ## Quick Start
 
@@ -21,7 +40,7 @@ Reflex’s hosting service makes it easy to deploy your apps without worrying ab
 
 ### Authentication
 
-First, create or log in to your account using the following command. (Requires Reflex > v0.3.1)
+First, create or log in to your account using the following command. (Requires Reflex > `v0.3.1`)
 
 ```bash
 reflex login
@@ -30,13 +49,16 @@ reflex login
 You will be prompted to your browser where you can create an account using Github or Gmail for authentication.
 
 ```python eval
-rx.alert(
-    rx.alert_icon(),
-    rx.alert_description("You will need an invitation code! Contact us on Discord if you have an app ready to deploy, and we will give you a code."
+callout_root(
+    callout_icon(icon(tag="lock_open_2", width=18, height=18)),
+    callout_text(
+        text("You will need an invitation code! Contact us on "),
+        link("Discord", href=constants.DISCORD_URL),
+        text(" if you have an app ready to deploy, and we will give you a code."),
     ),
-    status="info",
-    width="100%",
-    margin_bottom="1rem",
+    size="3",
+    color_scheme="green",
+    high_contrast=True,
 )
 ```
 
@@ -44,8 +66,18 @@ rx.alert(
 
 Once you have successfully logged in to your account, you can deploy your apps.
 
-TODO: style the sentence below.
-Make sure you include a requirements.txt with all your dependencies!
+```python eval
+callout_root(
+    callout_icon(icon(tag="info_circled", width=18, height=18)),
+    callout_text(
+        "Make sure you have a requirements.txt containing all your python dependencies at the top level app directory!",
+        color="black",
+        weight="bold"),
+    size="3",
+    color_scheme="blue",
+    high_contrast=True,
+)
+```
 
 Navigate to the project you want to deploy and type the following command:
 
@@ -61,4 +93,174 @@ That’s it! You should receive some feedback on the progress of your deployment
 
 Once your app is deployed, you will see a URL with your live site.
 
-Please follow the hosting guide here to deploy your app **(invitation code needed)**: [Reflex Hosting](https://reflex-dev.notion.site/Reflex-Hosting-Documentation-57a4dd55d6234858bbae0be75be79ce7?pvs=4)
+## Concepts
+
+### Environment Variables
+
+When deploying to Reflex hosting service, you will be asked if you want to add any environment variables. These are encrypted and safely stored. We will not show you the values of them any CLI commands, only the key names. Make sure to enter the Environment Variables without any quotation marks.
+
+Anything like backend API keys or secrets should be entered here and referenced in your app as an environment variable `os.environ` in the backend python code.
+
+### Redeployment
+
+To redeploy your app, navigate to your project directory and type `reflex deploy` again. This command communicates with the hosting service to automatically detects your existing app under the same name. If your current directory has a `rxconfig` that says your app name is `abc-app`, and you have already deployed an `abc-app`, and this time the deploy command overwrites it. You should see a prompt similar to `Overwriting your app abc-app ... `. This is a complete overwrite and not an incremental update.
+
+## Hosting CLI Commands
+
+All the commands come with help manual. Type `--help` to see it, for example, `reflex deploy --help`. The help manual provides additional options that may be useful.
+
+### Authentication Commands
+
+#### reflex login
+
+1. User types the command for the very first time, CLI opens the hosting service URL login page for user to use one of the OAuth providers to authorize and log in.
+2. After user authorizes OAuth access, the page redirects back to a page on the hosting service website. It shows elements only relevant to authenticated users, such as logout button. Note that we are frequently improving our website, the exact view for authenticated user may be different than described here.
+3. Your access token is cached locally in the reflex support directory. For subsequent login commands, as long as the access token is valid, the CLI shows “**You’re already logged in**” without opening up your browser again.
+4. Cont’d from 3: if the validation fails, the CLI shows 1) “**Session expired**” 2) “**User is banned**” 3) “**Access denied**” (for other cases we have no need to distinguish a bad token or just that user needs to re-authenticate) and CLI  will be opening the browser for re-authentication.
+5. If for any reason, there is no cached token on user machine, but the user session is still active on the browser, the hosting service login page will skip the step of redirecting to OAuth provider and show the same page described above in step 2.
+
+#### reflex logout
+
+1. User types this command, if no token is cached, CLI shows “**Login info not found**”
+2. If a token is found, (behind the scene: CLI makes a request to hosting service to delete/deactivate the access token. If the hosting service responds success, ) CLI shows “Successfully logged out”. (If hosting service responds with any error), CLI shows “**Unable to log out, please try again later**” (retryable errors), “**You’re not logged in**”. In all cases, the cached login config is deleted from user machine.
+
+### Deployment Commands
+
+#### reflex deploy
+
+Summary
+
+1. User types `reflex deploy` command.
+2. If not in the reflex app root directory (with the rxconfig file), alert “**You must be in the top level directory of your app to deploy**”
+3. If not `reflex init` before, it asks the user to run `reflex init` first, this is the same as `reflex run` command
+4. If the user does not have `requirements.txt` in the directory, alert.
+5. If not all the dependencies are installed, CLI accepts the import errors and alerts the user, “**Did you forget to install all dependencies?**”
+6. **Example 1** shows the sequences of a successful deployment.
+7. The deploy command by default interacts with the user and prompts for information. To provide all the settings for your app in a one shot without this interaction, use the `--no-interactive` flag. Type `reflex deploy --help` to see the help command for explanation on each flag. There is an example below: example 2. The deploy sequences are the same regardless the command is interactive or not. Example 2 skips the deploy sequences.
+
+#### reflex deployments list
+
+List all your deployments.
+
+#### reflex deployments status `app-name`
+
+#### reflex deployments logs `app-name`
+
+#### reflex deployments build-logs `app-name`
+
+#### reflex deployments delete `app-name`
+
+
+### Public Commands
+
+These commands do not require authentication.
+
+#### reflex deployments regions
+
+List all the valid regions to select for a deployment.
+
+```python eval
+table_root(
+    table_header(
+        table_row(
+            table_column_header_cell("Region Code"),
+            table_column_header_cell("Region"),
+        ),
+    ),
+    table_body(
+        table_row(
+            table_row_header_cell("alt"),
+            table_cell("Atlanta, Georgia (US)"),
+        ),
+        table_row(
+            table_row_header_cell("bog"),
+            table_cell("Bogotá, Colombia"),
+        ),
+        table_row(
+            table_row_header_cell("bos"),
+            table_cell("Boston, Massachusetts (US)"),
+        ),
+        table_row(
+            table_row_header_cell("cdg"),
+            table_cell("Paris, France"),
+        ),
+        table_row(
+            table_row_header_cell("den"),
+            table_cell("Denver, Colorado (US)"),
+        ),
+        table_row(
+            table_row_header_cell("dfw"),
+            table_cell("Dallas, Texas (US)"),
+        ),
+        table_row(
+            table_row_header_cell("eze"),
+            table_cell("Ezeiza, Argentina"),
+        ),
+        table_row(
+            table_row_header_cell("fra"),
+            table_cell("Frankfurt, Germany"),
+        ),
+        table_row(
+            table_row_header_cell("hkg"),
+            table_cell("Hong Kong, Hong Kong"),
+        ),
+        table_row(
+            table_row_header_cell("iad"),
+            table_cell("Ashburn, Virginia (US)"),
+        ),
+        table_row(
+            table_row_header_cell("lax"),
+            table_cell("Los Angeles, California (US)"),
+        ),
+        table_row(
+            table_row_header_cell("lhr"),
+            table_cell("London, United Kingdom"),
+        ),
+        table_row(
+            table_row_header_cell("mad"),
+            table_cell("Madrid, Spain"),
+        ),
+        table_row(
+            table_row_header_cell("mia"),
+            table_cell("Miami, Florida (US)"),
+        ),
+        table_row(
+            table_row_header_cell("ord"),
+            table_cell("Chicago, Illinois (US)"),
+        ),
+        table_row(
+            table_row_header_cell("scl"),
+            table_cell("Santiago, Chile"),
+        ),
+        table_row(
+            table_row_header_cell("sea"),
+            table_cell("Seattle, Washington (US)"),
+        ),
+        table_row(
+            table_row_header_cell("sin"),
+            table_cell("Singapore, Singapore"),
+        ),
+        table_row(
+            table_row_header_cell("sjc"),
+            table_cell("San Jose, California (US)"),
+        ),
+        table_row(
+            table_row_header_cell("syd"),
+            table_cell("Sydney, Australia"),
+        ),
+        table_row(
+            table_row_header_cell("waw"),
+            table_cell("Warsaw, Poland"),
+        ),
+        table_row(
+            table_row_header_cell("yul"),
+            table_cell("Montréal, Canada"),
+        ),
+        table_row(
+            table_row_header_cell("yyz"),
+            table_cell("Toronto, Canada"),
+        ),
+    ),
+    variant="surface",
+)
+```

--- a/docs/hosting/deploy.md
+++ b/docs/hosting/deploy.md
@@ -17,22 +17,6 @@ the hosting service comes in.
 Hosting is in Alpha. Please reach out to us on Discord if you are ready to deploy and we will give you an invitation code.
 ```
 
-```python eval
-callout_root(
-    callout_icon(icon(tag="info_circled", width=18, height=18)),
-    callout_text(
-        text("Hosting is in Alpha. Please reach out to us on "),
-        link("Discord", href=constants.DISCORD_URL),
-        text(" if you are ready to deploy and we will give you an invitation code."),
-        color_scheme="black",
-        font_weight="bold"
-    ),
-    size="3",
-    color_scheme="blue",
-    high_contrast=True,
-)
-```
-
 ## Quick Start
 
 Reflex’s hosting service makes it easy to deploy your apps without worrying about configuring the infrastructure.
@@ -41,43 +25,10 @@ Reflex’s hosting service makes it easy to deploy your apps without worrying ab
 This tutorial assumes you’ve successfully `reflex init` and `reflex run` your app.
 ```
 
-```python eval
-callout_root(
-    callout_icon(icon(tag="info_circled", width=18, height=18)),
-    callout_text(
-        text("This tutorial assumes you’ve successfully "),
-        code("reflex init"),
-        text(" and "),
-        code("reflex run"),
-        text(" your app"),
-        color="black",
-        font_weight="bold"
-    ),
-    size="3",
-    color_scheme="blue",
-    high_contrast=True,
-)
-```
-
 ### Authentication
 
 ```md alert info
 Hosting service requires `reflex>=0.3.2`.
-```
-
-```python eval
-callout_root(
-    callout_icon(icon(tag="info_circled", width=18, height=18)),
-    callout_text(
-        text("Hosting service requires "),
-        code("reflex>=0.3.2"),
-        color="black",
-        font_weight="bold",
-    ),
-    size="3",
-    color_scheme="green",
-    high_contrast=True,
-)
 ```
 
 First, create or log in to your account using the following command.
@@ -92,43 +43,12 @@ You will be prompted to your browser where you can authenticate through Github o
 You will need an invitation code! Contact us on Discord if you have an app ready to deploy, and we will give you a code.
 ```
 
-```python eval
-callout_root(
-    callout_icon(icon(tag="lock_open_2", width=18, height=18)),
-    callout_text(
-        text("You will need an invitation code! Contact us on "),
-        link("Discord", href=constants.DISCORD_URL),
-        text(" if you have an app ready to deploy, and we will give you a code."),
-        color="black",
-        font_weight="bold",
-    ),
-    size="3",
-    color_scheme="green",
-    high_contrast=True,
-)
-```
-
 ### Deployment
 
 Once you have successfully authenticated, you can deploy your apps.
 
 ```md alert warning
 Make sure you have a `requirements.txt`  file at the top level app directory that contains all your python dependencies!
-```
-
-```python eval
-callout_root(
-    callout_icon(icon(tag="info_circled", width=18, height=18)),
-    callout_text(
-        "Make sure you have a ",
-        code("requirements.txt"),
-        " file at the top level app directory that contains all your python dependencies !",
-        color="black",
-        weight="bold"),
-    size="3",
-    color_scheme="blue",
-    high_contrast=True,
-)
 ```
 
 Navigate to the project directory that you want to deploy and type the following command:
@@ -149,19 +69,6 @@ That’s it! You should receive some feedback on the progress of your deployment
 
 ```md alert info
 Once your code is uploaded, the hosting service will start the deployment. Exiting from the command from that point on **does not** affect the deployment process. The command prints a message when you can close the command without affecting the deployment.
-```
-
-```python eval
-callout_root(
-    callout_icon(icon(tag="info_circled", width=18, height=18)),
-    callout_text(
-        "Once your code is uploaded, the hosting service will start the deployment. Exiting from the command from that point on does not affect the deployment process. The command prints a message when you can close the command without affecting the deployment.",
-        color="black",
-        weight="bold"),
-    size="3",
-    color_scheme="green",
-    high_contrast=True,
-)
 ```
 
 ## Concepts

--- a/docs/hosting/deploy.md
+++ b/docs/hosting/deploy.md
@@ -11,12 +11,7 @@ from reflex.components.radix.themes.typography import *
 
 So far, we've been running our apps locally on our own machines.
 But what if we want to share our apps with the world?  This is where
-deployment comes in.
-
-```md alert info
-# Hosting is in Alpha
-Please reach out to us on Discord if you have an app ready to deploy and we will give you an invitation code.
-```
+the hosting service comes in.
 
 ```python eval
 callout_root(
@@ -24,9 +19,9 @@ callout_root(
     callout_text(
         text("Hosting is in Alpha. Please reach out to us on "),
         link("Discord", href=constants.DISCORD_URL),
-        text(" if you have an app ready to deploy and if we will give you an invitation code."),
+        text(" if you are ready to deploy and we will give you an invitation code."),
         color_scheme="black",
-        weight="bold"
+        font_weight="bold"
     ),
     size="3",
     color_scheme="blue",
@@ -36,7 +31,7 @@ callout_root(
 
 ## Quick Start
 
-Reflex’s hosting service makes it easy to deploy your apps without worrying about configuring your infrastructure.
+Reflex’s hosting service makes it easy to deploy your apps without worrying about configuring the infrastructure.
 
 ```python eval
 callout_root(
@@ -48,7 +43,7 @@ callout_root(
         code("reflex run"),
         text(" your app"),
         color="black",
-        weight="bold"
+        font_weight="bold"
     ),
     size="3",
     color_scheme="blue",
@@ -58,7 +53,22 @@ callout_root(
 
 ### Authentication
 
-First, create or log in to your account using the following command. (Requires `Reflex >= v0.3.2`)
+```python eval
+callout_root(
+    callout_icon(icon(tag="info_circled", width=18, height=18)),
+    callout_text(
+        text("Hosting service requires "),
+        code("reflex>=0.3.2"),
+        color="black",
+        font_weight="bold",
+    ),
+    size="3",
+    color_scheme="green",
+    high_contrast=True,
+)
+```
+
+First, create or log in to your account using the following command.
 
 ```bash
 reflex login
@@ -73,6 +83,8 @@ callout_root(
         text("You will need an invitation code! Contact us on "),
         link("Discord", href=constants.DISCORD_URL),
         text(" if you have an app ready to deploy, and we will give you a code."),
+        color="black",
+        font_weight="bold",
     ),
     size="3",
     color_scheme="green",
@@ -82,13 +94,15 @@ callout_root(
 
 ### Deployment
 
-Once you have successfully logged in to your account, you can deploy your apps.
+Once you have successfully authenticated, you can deploy your apps.
 
 ```python eval
 callout_root(
     callout_icon(icon(tag="info_circled", width=18, height=18)),
     callout_text(
-        "Make sure you have a requirements.txt containing all your python dependencies at the top level app directory!",
+        "Make sure you have a ",
+        code("requirements.txt"),
+        " file at the top level app directory that contains all your python dependencies !",
         color="black",
         weight="bold"),
     size="3",
@@ -97,43 +111,85 @@ callout_root(
 )
 ```
 
-Navigate to the project you want to deploy and type the following command:
+Navigate to the project directory that you want to deploy and type the following command:
 
 ```bash
 reflex deploy
 ```
 
-**Name**: choose a name for the deployed app. This name will be part of the deployed app URL, i.e. `<your-app-name>.reflex.run`. The name should only contain domain name safe characters: no slashes, no underscores. It is also case insensitive, so simply use all lower cases.
+The command is by default interactive. It asks you a few questions for information required for the deployment.
 
-**Regions**: check the list of regions you can select from [reflex deployments regions](#reflex-deployments-regions)
+**Name**: choose a name for the deployed app. This name will be part of the deployed app URL, i.e. `<app-name>.reflex.run`. The name should only contain domain name safe characters: no slashes, no underscores. Domain names are case insensitive. To avoid confusion, the name you choose here is also case insensitive. If you enter letters in upper cases, we automatically convert them to lower cases.
+
+**Regions**: enter the region code here or press `Enter` to accept the default. The default code `sjc` stands for San Jose, California in the US west coast. Check the list of supported regions at [reflex deployments regions](#reflex-deployments-regions).
+
+**Envs**: `Envs` are environment variables. You might not have used them at all in your app. In that case, press `Enter` to skip. More on the environment variables in the later section [Environment Variables](#environment-variables).
 
 That’s it! You should receive some feedback on the progress of your deployment and in a few minutes your app should be up. 🎉
 
+```python eval
+callout_root(
+    callout_icon(icon(tag="info_circled", width=18, height=18)),
+    callout_text(
+        "Once your code is uploaded, the hosting service will start the deployment. Exiting from the command from that point on does not affect the deployment process. The command prints a message when you can close the command without affecting the deployment.",
+        color="black",
+        weight="bold"),
+    size="3",
+    color_scheme="green",
+    high_contrast=True,
+)
+```
+
 ## Concepts
+
+### Requirements
+
+To be able to deploy your app, we ask that you prepare a `requirements.txt` file containing all the required Python packages for it. The hosting service runs a `pip install` command based on this file to prepare the instances that run your app. We recommend that  you use a Python virtual environment when starting a new app, and only install the necessary packages. This reduces the preparation time installing no more packages than needed, and your app is deployed faster. There are a lot of resources online on Python virtual environment tools and how to capture the packages in a `requirements.txt` file.
 
 ### Environment Variables
 
-When deploying to Reflex hosting service, you will be asked if you want to add any environment variables. These are encrypted and safely stored. We will not show you the values of them any CLI commands, only the key names. Make sure to enter the Environment Variables without any quotation marks.
+When deploying to Reflex's hosting service, the command prompt asks if you want to add any environment variables. These are encrypted and safely stored. We do not show the values of them in any CLI commands, only their names (or keys). We recommend that backend API keys or secrets are entered as `envs`. Make sure to enter the `Environment Variables` without any quotation marks.
 
-Anything like backend API keys or secrets should be entered here and referenced in your app as an environment variable `os.environ` in the backend python code.
+However, if your app intentionally prints the values of these variables, the logs returned still contain the printed values. At the moment, the logs are not censored against anything resembling secrets. Only the app owner and Reflex team admins can access these logs.
 
-### Redeployment
+The environment variables are key value pairs. You access their values by referencing their names as keys in `os.environ` in your app's backend. For example, if you set an env `ASYNC_DB_URL`, you are able to access it by `os.environ["ASYNC_DB_URL"]`. Some Python libraries automatically look for certain environment variables. For example, `OPENAI_API_KEY` for the `openai` python client. The `boto3` client credentials can be configured by setting `AWS_ACCESS_KEY_ID`,`AWS_SECRET_ACCESS_KEY`.
 
-To redeploy your app, navigate to your project directory and type `reflex deploy` again. This command communicates with the hosting service to automatically detects your existing app under the same name. If your current directory has a `rxconfig` that says your app name is `abc-app`, and you have already deployed an `abc-app`, and this time the deploy command overwrites it. You should see a prompt similar to `Overwriting your app abc-app ... `. This is a complete overwrite and not an incremental update.
+### Updating Deployment
+
+To redeploy or update your app, navigate to the project directory and type `reflex deploy` again. This command communicates with the hosting service to automatically detects your existing app by the same name. This time the deploy command overwrites the app. You should see a prompt similar to `Overwrite deployment [ app-name ] ...`. This operation is a complete overwrite and not an incremental update.
 
 ## Hosting CLI Commands
 
-All the commands come with help manual. Type `--help` to see it, for example, `reflex deploy --help`. The help manual provides additional options that may be useful.
+All the `reflex` commands come with a help manual. The help manual provides additional options that may be useful. You type `--help` to see the help manual. Some commands are organized under a `subcommands` series. Here is an example below. Note that the help manual may look different depending on the version of `reflex` or the `reflex-hosting-cli`.
+
+```python eval
+doccmdoutput(
+    command="reflex deployments --help",
+    output="""Usage: reflex deployments [OPTIONS] COMMAND [ARGS]...
+
+  Subcommands for managing the Deployments.
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  build-logs  Get the build logs for a deployment.
+  delete      Delete a hosted instance.
+  list        List all the hosted deployments of the authenticated user.
+  logs        Get the logs for a deployment.
+  regions     List all the regions of the hosting service.
+  status      Check the status of a deployment.
+"""
+)
+```
+
+`--loglevel` is another common `reflex` command option. When setting `--loglevel debug`, a command prints additional information, which can be helpful during debug.
 
 ### Authentication Commands
 
 #### reflex login
 
-1. User types the command for the very first time, CLI opens the hosting service URL login page for user to use one of the OAuth providers to authorize and log in.
-2. After user authorizes OAuth access, the page redirects back to a page on the hosting service website. It shows elements only relevant to authenticated users, such as logout button. Note that we are frequently improving our website, the exact view for authenticated user may be different than described here.
-3. Your access token is cached locally in the reflex support directory. For subsequent login commands, as long as the access token is valid, the CLI shows “**You’re already logged in**” without opening up your browser again.
-4. Cont’d from 3: if the validation fails, the CLI shows 1) “**Session expired**” 2) “**User is banned**” 3) “**Access denied**” (for other cases we have no need to distinguish a bad token or just that user needs to re-authenticate) and CLI  will be opening the browser for re-authentication.
-5. If for any reason, there is no cached token on user machine, but the user session is still active on the browser, the hosting service login page will skip the step of redirecting to OAuth provider and show the same page described above in step 2.
+When you type the `reflex login` command for the very first time, it opens the hosting service login page. We authenticate users through OAuth. At the moment the supported OAuth providers are Github and Gmail. You should be able to revoke such authorization on your Github and Google account settings page. We do not log into your Github or Gmail account. OAuth authorization provides us your email address and in case of Github your username handle. We use those to create an account for you. When you return, the email used in the original account creation is used to identify you as a user. If you have authenticated using different emails, those create separate accounts. To switch to another account, first log out using the `reflex logout` command. More details on the logout command are in [reflex logout](#reflex-logout) section.
 
 ```python eval
 doccmdoutput(
@@ -144,24 +200,19 @@ Successfully logged in.
 )
 ```
 
+After authenticated, the browser redirects to the original hosting service page. It shows you have logged in. Now you can return to the terminal where you type the login command. It should print a message such as `Successfully logged in`.
+
+Your access token is cached locally in the reflex support directory. For subsequent login commands, the cached token is validated first. If the token is still valid, the CLI command simply shows `You’re already logged in`. If the token is expired or simply not valid for any reason, the login command tries to open your browser again for web based authentication.
+
 #### reflex logout
 
-1. User types this command, if no token is cached, CLI shows “**Login info not found**”
-2. If a token is found, (behind the scene: CLI makes a request to hosting service to delete/deactivate the access token. If the hosting service responds success, ) CLI shows “Successfully logged out”. (If hosting service responds with any error), CLI shows “**Unable to log out, please try again later**” (retryable errors), “**You’re not logged in**”. In all cases, the cached login config is deleted from user machine.
+When you successfully authenticate with the hosting service, there is information cached in two different places: a file containing the access token in the reflex support folder, and cookies in your browser. The cookies include the access token, a refresh token, some unix epochs indicating when the access token expires. The logout command removes the cached information from these places.
 
 ### Deployment Commands
 
 #### reflex deploy
 
-Summary
-
-1. User types `reflex deploy` command.
-2. If not in the reflex app root directory (with the rxconfig file), alert “**You must be in the top level directory of your app to deploy**”
-3. If not `reflex init` before, it asks the user to run `reflex init` first, this is the same as `reflex run` command
-4. If the user does not have `requirements.txt` in the directory, alert.
-5. If not all the dependencies are installed, CLI accepts the import errors and alerts the user, “**Did you forget to install all dependencies?**”
-6. **Example 1** shows the sequences of a successful deployment.
-7. The deploy command by default interacts with the user and prompts for information. To provide all the settings for your app in a one shot without this interaction, use the `--no-interactive` flag. Type `reflex deploy --help` to see the help command for explanation on each flag. There is an example below: example 2. The deploy sequences are the same regardless the command is interactive or not. Example 2 skips the deploy sequences.
+This is the command to deploy a reflex app from its top level app directory. This directory contains a `rxconfig.py` where you run `reflex init` and `reflex run`. A `requirements.txt` file is required. The deploy command checks the existence of this file and also the content of it (this is available in more recent versions of `reflex-hosting-cli` such as `0.1.3`). The command prompts you for updates on the requirements when there are new packages or newer versions of packages detected in the Python environment.
 
 ```python eval
 doccmdoutput(
@@ -186,7 +237,9 @@ Your site [ todo ] at ['lax'] is up: https://todo.reflex.run
 )
 ```
 
-The non-interactive deploy command requires user to provide all the required information, such as the app name of your choice, the regions to deploy to, environmental variables if you have them.
+The deploy command is by default interactive and prompts you for information. To provide all the settings for your app in one shot without the interaction, add the `--no-interactive` option. Type `reflex deploy --help` to see the help command for explanation on each option. The deploy sequences are the same whether the command is interactive or not.
+
+The non-interactive deploy command requires you to provide all the required information, such as the app name of your choice, the regions to deploy to, environmental variables if you have them.
 
 ```bash
 reflex deploy --no-interactive -k todo -r sjc -r sea --env OPENAI_API_KEY=YOU-KEY-NO-EXTRA-QUOTES --env DB_URL=YOUR-EXTERNAL-DB-URI --env KEY3=THATS-ALOTOF-KEYS
@@ -213,35 +266,39 @@ basic-crud-navy-apple         ['dfw']  basic_crud            0.3.8              
 
 #### reflex deployments status `app-name`
 
-Get the status of a specific app.
+Get the status of a specific app, including backend and frontend.
 
 ```python eval
 doccmdoutput(
     command="reflex deployments status clock-gray-piano",
     output="""Getting status for [ clock-gray-piano ] ...
 
-backend_url                               reachable    updated_at
-----------------------------------------  -----------  ------------
-https://rxh-dev-clock-gray-piano.fly.dev  False        N/A
+backend_url                                reachable    updated_at
+-----------------------------------------  -----------  ------------
+https://rxh-prod-clock-gray-piano.fly.dev  False        N/A
 
 
-frontend_url                                 reachable    updated_at
--------------------------------------------  -----------  -----------------------
-https://clock-gray-piano.dev.reflexcorp.run  True         2023-10-13 15:23:07 PDT
+frontend_url                               reachable    updated_at
+-----------------------------------------  -----------  -----------------------
+https://clock-gray-piano.reflex.run        True         2023-10-13 15:23:07 PDT
 """,
 )
 ```
 
 #### reflex deployments logs `app-name`
 
-Get the logs from a specified deployment.
+Get the logs from a specific deployment.
+
+The returned logs are the console messages. If you have `print` statements in your code, they show up in these logs. By default, the logs command return the latest 100 lines of logs and continue to stream any new lines.
+
+We have added more options to this command including `from` and `to` timestamps and the limit on how many lines of logs to fetch. Accepted timestamp formats include the ISO 8601 format, unix epoch and relative timestamp. A relative timestamp is some time units ago from `now`. The units are `d (day), h (hour), m (minute), s (second)`. For example, `--from 3d --to 4h` queries from 3 days ago up to 4 hours ago. For the exact syntax in the version of CLI you use, refer to the help manual.
 
 ```python eval
 doccmdoutput(
     command="reflex deployments logs todo",
     output="""Note: there is a few seconds delay for logs to be available.
 2023-10-13 22:18:39.696028 | rxh-dev-todo | info | Pulling container image registry.fly.io/rxh-dev-todo:depot-1697235471
-2023-10-13 22:18:41.462929 | rxh-dev-todo | info | Pulling Gcontainer image registry.fly.io/rxh-dev-todo@sha256:60b7b531e99e037f2fb496b3e05893ee28f93a454ee618bda89a531a547c4002
+2023-10-13 22:18:41.462929 | rxh-dev-todo | info | Pulling container image registry.fly.io/rxh-dev-todo@sha256:60b7b531e99e037f2fb496b3e05893ee28f93a454ee618bda89a531a547c4002
 2023-10-13 22:18:45.963840 | rxh-dev-todo | info | Successfully prepared image registry.fly.io/rxh-dev-todo@sha256:60b7b531e99e037f2fb496b3e05893ee28f93a454ee618bda89a531a547c4002 (4.500906837s)
 2023-10-13 22:18:46.134860 | rxh-dev-todo | info | Successfully prepared image registry.fly.io/rxh-dev-todo:depot-1697235471 (6.438815793s)
 2023-10-13 22:18:46.210583 | rxh-dev-todo | info | Configuring firecracker
@@ -284,9 +341,13 @@ doccmdoutput(
 )
 ```
 
+The hosting service prints log messages when preparing and deploying your app. These log messages are called build logs. Build logs are useful in troubleshooting deploy failures. For example, if there is a package `numpz==1.26.3` (supposed to be `numpy`) in the `requirements.txt`, hosting service will be unable to install it. That package does not exist. We expect to find a few lines in the build logs indicating that the `pip install` command fails.
+
+During the deploy command, we print a few lines of the deploy sequence "milestones" from the build logs, such as `Backend updated!`, `Deploy success (frontend)`.
+
 #### reflex deployments delete `app-name`
 
-Delete a specified deployment.
+Delete a specific deployment.
 
 ### Public Commands
 

--- a/docs/hosting/deploy.md
+++ b/docs/hosting/deploy.md
@@ -144,21 +144,50 @@ This is the command to deploy a reflex app from its top level app directory. Thi
 ```python eval
 doccmdoutput(
     command="reflex deploy",
-    output="""Name of deployment (todo-blue-ocean): todo
-Region to deploy to (sjc): lax
-Environment variables ...
-  Env name (enter to skip):
-No envs added. Continuing ...
--------------------------- Compiling production app and preparing for export. -------------------
-Compiling:  ---------------------------------------- 100% 2/2 0:00:00
-Creating Production Build:  ---------------------------------------- 100% 9/9 0:00:08
-Zipping Frontend: --------------------------------------- 100% 19/19 0:00:00
-Zipping Backend: ---------------------------------------- 100% 4/4 0:00:00
-Uploading code ...
-Deployment will start shortly.
+    output="""Info: The requirements.txt may need to be updated.
+--- requirements.txt
++++ new_requirements.txt
+@@ -1,3 +1,3 @@
+-reflex>=0.2.0
+-openai==0.28
++openai==0.28.0
++reflex==0.3.8
+
+Would you like to update requirements.txt based on the changes above? [y/n]: y
+
+Choose a name for your deployed app (https://<picked-name>.reflex.run)
+Enter to use default. (webui-gray-sun): demo-chat
+Region to deploy to. See regions: https://bit.ly/46Qr3mF
+Enter to use default. (sjc): lax
+Environment variables for your production App ...
+ * env-1 name (enter to skip): OPENAI_API_KEY
+   env-1 value: sk-*********************
+ * env-2 name (enter to skip):
+Finished adding envs.
+──────────────── Compiling production app and preparing for export. ────────────────
+Zipping Backend: ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 12/12 0:00:00
+Uploading Backend code and sending request ...
+Backend deployment will start shortly.
+──────────────── Compiling production app and preparing for export. ────────────────
+Compiling: ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 9/9 0:00:00
+Creating Production Build:  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 9/9 0:00:07
+Zipping Frontend: ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 20/20 0:00:00
+Uploading Frontend code and sending request ...
+Frontend deployment will start shortly.
+───────────────────────────── Deploying production app. ────────────────────────────
+Deployment will start shortly: https://demo-chat.reflex.run
+Closing this command now will not affect your deployment.
+Waiting for server to report progress ...
+2024-01-12 12:24:54.188271 PST | Updating frontend...
+2024-01-12 12:24:55.074264 PST | Frontend updated!
+2024-01-12 12:24:55.137679 PST | Deploy success (frontend)
+2024-01-12 12:24:59.722384 PST | Updating backend...
+2024-01-12 12:25:01.006386 PST | Building backend image...
+2024-01-12 12:26:03.672379 PST | Deploying backend image...
+2024-01-12 12:26:21.017946 PST | Backend updated!
+2024-01-12 12:26:21.018003 PST | Deploy success (backend)
 Waiting for the new deployment to come up
-...
-Your site [ todo ] at ['lax'] is up: https://todo.reflex.run
+Your site [ demo-chat ] at ['lax'] is up: https://demo-chat.reflex.run
 """,
 )
 ```

--- a/pcweb/flexdown.py
+++ b/pcweb/flexdown.py
@@ -10,6 +10,7 @@ from pcweb.templates.docpage import (
     h1_comp,
     h2_comp,
     h3_comp,
+    h4_comp,
     text_comp,
 )
 
@@ -82,6 +83,7 @@ component_map = {
     "h1": lambda text: h1_comp(text=text),
     "h2": lambda text: h2_comp(text=text),
     "h3": lambda text: h3_comp(text=text),
+    "h4": lambda text: h4_comp(text=text),
     "p": lambda text: text_comp(text=text),
     "a": doclink2,
     "code": lambda text: code_comp(text=text),

--- a/pcweb/pages/docs/__init__.py
+++ b/pcweb/pages/docs/__init__.py
@@ -33,11 +33,7 @@ for doc in sorted(flexdown_docs):
     title = rx.utils.format.to_snake_case(doc.rsplit("/", 1)[1].replace(".md", ""))
     category = doc.split("/")[-2].title()
     d = flexdown.parse_file(doc)
-    if doc.startswith("docs/library/chakra"):
-        clist = [eval(c) for c in d.metadata["components"]]
-        chakra_components[category].append(clist)
-        comp = multi_docs(path=route, comp=d, component_list=clist, title=title)
-    elif doc.startswith("docs/library"):
+    if doc.startswith("docs/library"):
         clist = [eval(c) for c in d.metadata["components"]]
         component_list[category].append(clist)
         comp = multi_docs(path=route, comp=d, component_list=clist, title=title)

--- a/pcweb/pages/docs/__init__.py
+++ b/pcweb/pages/docs/__init__.py
@@ -33,7 +33,11 @@ for doc in sorted(flexdown_docs):
     title = rx.utils.format.to_snake_case(doc.rsplit("/", 1)[1].replace(".md", ""))
     category = doc.split("/")[-2].title()
     d = flexdown.parse_file(doc)
-    if doc.startswith("docs/library"):
+    if doc.startswith("docs/library/chakra"):
+        clist = [eval(c) for c in d.metadata["components"]]
+        chakra_components[category].append(clist)
+        comp = multi_docs(path=route, comp=d, component_list=clist, title=title)
+    elif doc.startswith("docs/library"):
         clist = [eval(c) for c in d.metadata["components"]]
         component_list[category].append(clist)
         comp = multi_docs(path=route, comp=d, component_list=clist, title=title)

--- a/pcweb/templates/docpage.py
+++ b/pcweb/templates/docpage.py
@@ -427,6 +427,79 @@ def h3_comp(text: rx.Var[str]) -> rx.Component:
     )
 
 
+def doccmdoutput(
+    command: str,
+    output: str,
+) -> rx.Component:
+    """Create a documentation code snippet.
+
+    Args:
+        command: The command to display.
+        output: The output of the command.
+        theme: The theme of the component.
+
+    Returns:
+        The styled command and its example output.
+    """
+    return flex(
+        flex(
+            icon(tag="double_arrow_right"),
+            rx.code_block(
+                command,
+                border_radius=styles.DOC_BORDER_RADIUS,
+                background="transparent",
+                color_scheme="black",
+                language="bash",
+                code_tag_props={
+                    "style": {
+                        "fontFamily": "inherit",
+                    }
+                },
+            ),
+            rx.button(
+                rx.icon(tag="copy"),
+                on_click=rx.set_clipboard(command),
+                position="absolute",
+                top="0.5em",
+                right="0.5em",
+                color=tc["docs"]["body"],
+                background="transparent",
+                _hover={
+                    "background": "transparent",
+                    "color": styles.ACCENT_COLOR,
+                },
+            ),
+            direction="row",
+            align="center",
+            gap="1",
+            margin_left="1em",
+        ),
+        separator(
+            size="4",
+        ),
+        flex(
+            rx.code_block(
+                output,
+                border_radius=styles.DOC_BORDER_RADIUS,
+                background="transparent",
+                language="log",
+                code_tag_props={
+                    "style": {
+                        "fontFamily": "inherit",
+                    }
+                },
+            ),
+        ),
+        direction="column",
+        gap="2",
+        border_radius=styles.DOC_BORDER_RADIUS,
+        border="2px solid #F4F3F6",
+        position="relative",
+        margin="1em",
+        width="100%",
+    )
+
+
 def doccode(
     code: str,
     language: str = "python",

--- a/pcweb/templates/docpage.py
+++ b/pcweb/templates/docpage.py
@@ -443,12 +443,12 @@ def doccmdoutput(
     """
     return flex(
         flex(
-            icon(tag="double_arrow_right"),
+            icon(tag="double_arrow_right", color="white", width=18, height=18),
             rx.code_block(
                 command,
                 border_radius=styles.DOC_BORDER_RADIUS,
                 background="transparent",
-                color_scheme="black",
+                theme="a11y-dark",
                 language="bash",
                 code_tag_props={
                     "style": {
@@ -474,14 +474,13 @@ def doccmdoutput(
             gap="1",
             margin_left="1em",
         ),
-        separator(
-            size="4",
-        ),
+        separator(size="4", color_scheme="green"),
         flex(
             rx.code_block(
                 output,
                 border_radius=styles.DOC_BORDER_RADIUS,
                 background="transparent",
+                theme="a11y-dark",
                 language="log",
                 code_tag_props={
                     "style": {
@@ -497,6 +496,7 @@ def doccmdoutput(
         position="relative",
         margin="1em",
         width="100%",
+        background_color="black",
     )
 
 

--- a/pcweb/templates/docpage.py
+++ b/pcweb/templates/docpage.py
@@ -335,8 +335,14 @@ def code_comp(text: rx.Var[str]) -> rx.Component:
     return rx.code(text, color="#1F1944", bg="#EAE4FD")
 
 
-@rx.memo
-def h1_comp(text: rx.Var[str]) -> rx.Component:
+def h_comp_common(
+    text: rx.Var[str],
+    heading: str,
+    font_size: list[str] | str,
+    font_weight: str,
+    margin_top: str,
+    scroll_margin: str,
+) -> rx.Component:
     id_ = text.to(list[str])[0].lower().split().join("-")
     href = rx.State.router.page.full_path + "#" + id_
 
@@ -346,9 +352,10 @@ def h1_comp(text: rx.Var[str]) -> rx.Component:
                 rx.heading(
                     text,
                     id=id_,
-                    as_="h1",
-                    font_size=styles.H1_FONT_SIZE,
-                    font_weight=fw["heading"],
+                    as_=heading,
+                    font_size=font_size,
+                    font_weight=font_weight,
+                    scroll_margin=scroll_margin,
                 ),
                 rx.icon(
                     tag="link",
@@ -367,63 +374,57 @@ def h1_comp(text: rx.Var[str]) -> rx.Component:
             on_click=lambda: rx.set_clipboard(href),
         ),
         rx.divider(margin_y="1em"),
+        margin_top=margin_top,
         color=tc["docs"]["header"],
         width="100%",
+    )
+
+
+@rx.memo
+def h1_comp(text: rx.Var[str]) -> rx.Component:
+    return h_comp_common(
+        text=text,
+        heading="h1",
+        font_size=styles.H1_FONT_SIZE,
+        font_weight=fw["heading"],
+        margin_top="0",
+        scroll_margin="4em",
     )
 
 
 @rx.memo
 def h2_comp(text: rx.Var[str]) -> rx.Component:
-    id_ = text.to(list[str])[0].lower().split().join("-")
-    href = rx.State.router.page.full_path + "#" + id_
-
-    return rx.box(
-        rx.link(
-            rx.hstack(
-                rx.heading(
-                    text,
-                    id=id_,
-                    as_="h2",
-                    font_size=styles.H3_FONT_SIZE,
-                    font_weight=fw["subheading"],
-                ),
-                rx.icon(
-                    tag="link",
-                    color="#696287",
-                    _hover={
-                        "color": styles.ACCENT_COLOR,
-                    },
-                ),
-                align_items="center",
-            ),
-            _hover={
-                "cursor": "pointer",
-                "textDecoration": "none",
-            },
-            href=href,
-            on_click=lambda: rx.set_clipboard(href),
-        ),
-        rx.divider(margin_y="1em"),
+    return h_comp_common(
+        text=text,
+        heading="h2",
+        font_size=styles.H3_FONT_SIZE,
+        font_weight=fw["subheading"],
         margin_top="1.5em",
-        color=tc["docs"]["header"],
-        width="100%",
-        scroll_margin_top="4em",
+        scroll_margin="5em",
     )
 
 
 @rx.memo
 def h3_comp(text: rx.Var[str]) -> rx.Component:
-    return rx.box(
-        rx.heading(
-            text,
-            as_="h3",
-            font_size=styles.H4_FONT_SIZE,
-            font_weight=fw["subheading"],
-        ),
-        rx.divider(margin_y="1em"),
+    return h_comp_common(
+        text=text,
+        heading="h3",
+        font_size=styles.H4_FONT_SIZE,
+        font_weight=fw["subheading"],
         margin_top="1.5em",
-        color=tc["docs"]["header"],
-        width="100%",
+        scroll_margin="5em",
+    )
+
+
+@rx.memo
+def h4_comp(text: rx.Var[str]) -> rx.Component:
+    return h_comp_common(
+        text=text,
+        heading="h4",
+        font_size=styles.H4_FONT_SIZE,
+        font_weight=fw["subheading"],
+        margin_top="1.5em",
+        scroll_margin="6em",
     )
 
 


### PR DESCRIPTION
## Summary
- Transfer content from Notion doc to website.
- Update the command and example output.
- Add a helper to create a command + example console output component.
- Refactor the `h1_comp`, `h2_comp`, `h3_comp` to use the same helper function. Add a h4. All headings have the same anchor and click to scroll.