### PR TITLE
Replace backslash with forward slash

### DIFF
--- a/pcweb/pages/docs/__init__.py
+++ b/pcweb/pages/docs/__init__.py
@@ -66,7 +66,7 @@ for doc in sorted(flexdown_docs):
         continue
 
     # Get the docpage component.
-    route = f"/{doc.replace('.md', '')}"
+    route = f"/{doc.replace('.md', '')}".replace("\\", "/")
     path = doc.split("/")[1:-1]
     title = rx.utils.format.to_snake_case(os.path.basename(doc).replace(".md", ""))
     category = os.path.basename(os.path.dirname(doc)).title()

--- a/pcweb/pages/docs/__init__.py
+++ b/pcweb/pages/docs/__init__.py
@@ -66,7 +66,8 @@ for doc in sorted(flexdown_docs):
         continue
 
     # Get the docpage component.
-    route = f"/{doc.replace('.md', '')}".replace("\\", "/")
+    doc = doc.replace("\\", "/")
+    route = f"/{doc.replace('.md', '')}"
     path = doc.split("/")[1:-1]
     title = rx.utils.format.to_snake_case(os.path.basename(doc).replace(".md", ""))
     category = os.path.basename(os.path.dirname(doc)).title()

--- a/pcweb/pcweb.py
+++ b/pcweb/pcweb.py
@@ -8,6 +8,12 @@ import reflex.components.radix.themes as rdxt
 from pcweb import styles
 from pcweb.pages import page404, routes
 
+
+# This number discovered by trial and error on Windows 11 w/ Node 18, any
+# higher and the prod build fails with EMFILE error.
+WINDOWS_MAX_ROUTES = 125
+
+
 # Create the app.
 app = rx.App(
     style=styles.BASE_STYLE,
@@ -36,7 +42,7 @@ if sys.platform == "win32":
             "reflex-web cannot be built on Windows due to EMFILE error. To build a "
             "subset of pages for testing, set environment variable REFLEX_WEB_WINDOWS_OVERRIDE."
         )
-    routes = routes[:150]
+    routes = routes[:WINDOWS_MAX_ROUTES]
 
 
 # Add the pages to the app.

--- a/pcweb/pcweb.py
+++ b/pcweb/pcweb.py
@@ -1,5 +1,8 @@
 """The main Reflex website."""
 
+import os
+import sys
+
 import reflex as rx
 import reflex.components.radix.themes as rdxt
 from pcweb import styles
@@ -24,6 +27,17 @@ gtag('config', 'G-4T7C8ZD9TR');
         ),
     ],
 )
+
+
+# XXX: The app is TOO BIG to build on Windows, so explicitly disallow it except for testing
+if sys.platform == "win32":
+    if not os.environ.get("REFLEX_WEB_WINDOWS_OVERRIDE"):
+        raise RuntimeError(
+            "reflex-web cannot be built on Windows due to EMFILE error. To build a "
+            "subset of pages for testing, set environment variable REFLEX_WEB_WINDOWS_OVERRIDE."
+        )
+    routes = routes[:150]
+
 
 # Add the pages to the app.
 for route in routes:


### PR DESCRIPTION
I'm not crazy about this fix, but it's a short term solution.

Ideally we can rewrite the path handling stuff using `pathlib`, and then get these uri-style paths via [`as_posix`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.as_posix) API.

CI runs still failing though: https://github.com/reflex-dev/reflex/actions/runs/7566517188/job/20604025206?pr=2414#step:8:2697

```console
[Error: EMFILE: too many open files, open 
'D:\a\reflex\reflex\reflex-web\.web\node_modules\next\dist\server\require-hook.
js'] {
  errno: -4066,
  code: 'EMFILE',
  syscall: 'open',
  path: 
'D:\\a\\reflex\\reflex\\reflex-web\\.web\\node_modules\\next\\dist\\server\\req
uire-hook.js'
}
```

I'm seeing this even on my local windows VM as well.