### PR TITLE
[REF-1708] Rename "files_router_methods" to "router_attributes"

### DIFF
--- a/docs/utility_methods/router_attributes.md
+++ b/docs/utility_methods/router_attributes.md
@@ -32,7 +32,7 @@ The `self.router` attribute has several sub-attributes that provide various info
 
 ### Example Values on this Page
 
-```python demo exec align-items=start
+```python demo exec alignItems=start
 class RouterState(rx.State):
     pass
 

--- a/docs/utility_methods/router_attributes.md
+++ b/docs/utility_methods/router_attributes.md
@@ -7,7 +7,7 @@ import reflex as rx
 The state object has several methods and attributes that return information
 about the current page, session, or state.
 
-## Files Router Methods
+## Router Attributes
 
 The `self.router` attribute has several sub-attributes that provide various information:
 
@@ -32,7 +32,7 @@ The `self.router` attribute has several sub-attributes that provide various info
 
 ### Example Values on this Page
 
-```python demo exec
+```python demo exec align-items=start
 class RouterState(rx.State):
     pass
 

--- a/pcweb/components/sidebar.py
+++ b/pcweb/components/sidebar.py
@@ -263,7 +263,7 @@ def get_sidebar_items_backend():
         create_item(
             "Utility Methods",
             children=[
-                utility_methods.files_router_methods,
+                utility_methods.router_attributes,
                 utility_methods.other_methods,
             ],
         ),

--- a/pcweb/flexdown.py
+++ b/pcweb/flexdown.py
@@ -164,6 +164,8 @@ class DemoBlock(flexdown.blocks.Block):
         lines = self.get_lines(env)
         code = "\n".join(lines[1:-1])
 
+        demobox_props = {}
+
         args = lines[0].removeprefix(self.starting_indicator).split()
 
         if "exec" in args:
@@ -183,8 +185,10 @@ class DemoBlock(flexdown.blocks.Block):
             return rx.box(docdemobox(comp), margin_bottom="1em")
         else:
             comp = eval(code, env, env)
+        if "align-items=start" in args:
+            demobox_props = {"align-items": "start"}
 
-        return docdemo(code, comp=comp)
+        return docdemo(code, comp=comp, demobox_props=demobox_props)
 
 
 component_map = {

--- a/pcweb/flexdown.py
+++ b/pcweb/flexdown.py
@@ -164,8 +164,6 @@ class DemoBlock(flexdown.blocks.Block):
         lines = self.get_lines(env)
         code = "\n".join(lines[1:-1])
 
-        demobox_props = {}
-
         args = lines[0].removeprefix(self.starting_indicator).split()
 
         if "exec" in args:
@@ -185,8 +183,13 @@ class DemoBlock(flexdown.blocks.Block):
             return rx.box(docdemobox(comp), margin_bottom="1em")
         else:
             comp = eval(code, env, env)
-        if "align-items=start" in args:
-            demobox_props = {"align-items": "start"}
+
+        # Sweep up additional CSS-like props to apply to the demobox itself
+        demobox_props = {}
+        for arg in args:
+            prop, equals, value = arg.partition("=")
+            if equals:
+                demobox_props[prop] = value
 
         return docdemo(code, comp=comp, demobox_props=demobox_props)
 


### PR DESCRIPTION
Update DemoBlock to allow passing `align-items=start` to align the demo to the left of the demobox and allow scrolling all the way to the right.