### PR TITLE
Do not require redis in rxconfig.py

### DIFF
--- a/rxconfig.py
+++ b/rxconfig.py
@@ -15,5 +15,4 @@ config = rx.Config(
             "@tailwindcss/typography",
         ],
     },
-    redis_url="localhost:6379",
 )


### PR DESCRIPTION
This is breaking my local development workflow. We should just use `REDIS_URL` when deploying in production.