### PR TITLE
Replace windows style path separator where needed

### DIFF
--- a/pcweb/pages/docs/__init__.py
+++ b/pcweb/pages/docs/__init__.py
@@ -87,7 +87,10 @@ def get_components_from_metadata(current_doc):
     return components
 
 
-flexdown_docs = flexdown.utils.get_flexdown_files("docs/")
+flexdown_docs = [
+    doc.replace("\\", "/")
+    for doc in flexdown.utils.get_flexdown_files("docs/")
+]
 
 chakra_components = defaultdict(list)
 radix_components = defaultdict(list)


### PR DESCRIPTION
A recent change moved this previous replacement into a function-local variable so it didn't persist outside of that function call.

Therefore, make the replacement again, where needed.

Unbreak windows CI

Testing against live CI in https://github.com/reflex-dev/reflex/pull/2572