### PR TITLE
Remove chakra checkbox group docs

### DIFF
--- a/docs/library/chakra/forms/checkbox.md
+++ b/docs/library/chakra/forms/checkbox.md
@@ -67,18 +67,3 @@ def checkbox_state_example():
         )
     )
 ```
-
-## Checkbox Group
-
-You can group checkboxes together using checkbox group.
-
-```python demo
-rx.chakra.checkbox_group(
-    rx.chakra.checkbox("Example", color_scheme="green"),
-    rx.chakra.checkbox("Example", color_scheme="blue"),
-    rx.chakra.checkbox("Example", color_scheme="yellow"),
-    rx.chakra.checkbox("Example", color_scheme="orange"),
-    rx.chakra.checkbox("Example", color_scheme="red"),
-    space="1em",
-)
-```

--- a/docs/recipes/checkboxes.md
+++ b/docs/recipes/checkboxes.md
@@ -38,17 +38,15 @@ import reflex as rx
 
 def render_checkboxes(values, limit, handler):
     return rx.vstack(
-        rx.checkbox_group(
             rx.foreach(
                 values,
                 lambda choice: rx.checkbox(
                     choice[0],
-                    is_checked=choice[1],
-                    is_disabled=~choice[1] & limit,
+                    checked=choice[1],
+                    disabled=~choice[1] & limit,
                     on_change=lambda val: handler(val, choice[0]),
                 ),
             )
-        )
     )
 
 


### PR DESCRIPTION
The chakra checkbox group doesnt add substantial value to its use with chakra checkbox. It is currently unmaintained (prop field types eg. `default_value` is incorrect). Also seem to be buggy when used with reflex's chakra checkbox because of the implementation of `id` and `name` fields. Since chakra is getting deprecated, this PR removes chakra group from the api reference as well as fix the recipe to use radix checkbox