### PR TITLE
Add drawer docs

### DIFF
--- a/docs/library/overlay/drawer.md
+++ b/docs/library/overlay/drawer.md
@@ -1,0 +1,45 @@
+---
+components:
+    - rx.radix.drawer.root
+    - rx.radix.drawer.trigger
+    - rx.radix.drawer.overlay
+    - rx.radix.drawer.portal
+    - rx.radix.drawer.content
+    - rx.radix.drawer.close
+
+only_low_level:
+    - True
+---
+
+```python exec
+import reflex as rx
+```
+
+
+# Drawer
+
+```python demo
+rx.drawer.root(
+        rx.drawer.trigger(
+            rx.button("Open Drawer")    
+        ),
+        rx.drawer.overlay(),
+        rx.drawer.portal(
+            rx.drawer.content(
+                rx.flex(
+                    rx.drawer.close(rx.box(rx.button("Close"))),
+                    align_items="start",
+                    direction="column",
+                ),
+                top="auto",
+                right="auto",
+                height="100%",
+                width="20em",
+                padding="2em",
+                background_color="#FFF"
+                #background_color=rx.color("green", 3)
+            )
+        ),
+        direction="left",
+)
+```

--- a/docs/library/overlay/dropdownmenu.md
+++ b/docs/library/overlay/dropdownmenu.md
@@ -12,7 +12,7 @@ only_low_level:
 
 DropdownMenuRoot: |
     lambda **props: rx.menu.root(
-        rx.menu.trigger(rx.radix.themes.button("drop down menu")),
+        rx.menu.trigger(rx.button("drop down menu")),
         rx.menu.content(
             rx.menu.item("Edit", shortcut="⌘ E"),
             rx.menu.item("Share"),
@@ -31,7 +31,7 @@ DropdownMenuRoot: |
 
 DropdownMenuContent: |
     lambda **props: rx.menu.root(
-        rx.menu.trigger(rx.radix.themes.button("drop down menu")),
+        rx.menu.trigger(rx.button("drop down menu")),
         rx.menu.content(
             rx.menu.item("Edit", shortcut="⌘ E"),
             rx.menu.item("Share"),
@@ -50,7 +50,7 @@ DropdownMenuContent: |
 
 DropdownMenuItem: |
     lambda **props: rx.menu.root(
-        rx.menu.trigger(rx.radix.themes.button("drop down menu")),
+        rx.menu.trigger(rx.button("drop down menu")),
         rx.menu.content(
             rx.menu.item("Edit", shortcut="⌘ E", **props),
             rx.menu.item("Share", **props),
@@ -68,7 +68,7 @@ DropdownMenuItem: |
 
 DropdownMenuSub: |
     lambda **props: rx.menu.root(
-        rx.menu.trigger(rx.radix.themes.button("drop down menu")),
+        rx.menu.trigger(rx.button("drop down menu")),
         rx.menu.content(
             rx.menu.item("Edit", shortcut="⌘ E"),
             rx.menu.item("Share"),
@@ -87,7 +87,7 @@ DropdownMenuSub: |
 
 DropdownMenuSubTrigger: |
     lambda **props: rx.menu.root(
-        rx.menu.trigger(rx.radix.themes.button("drop down menu")),
+        rx.menu.trigger(rx.button("drop down menu")),
         rx.menu.content(
             rx.menu.item("Edit", shortcut="⌘ E"),
             rx.menu.item("Share"),
@@ -105,7 +105,7 @@ DropdownMenuSubTrigger: |
 
 DropdownMenuSubContent: |
     lambda **props: rx.menu.root(
-        rx.menu.trigger(rx.radix.themes.button("drop down menu")),
+        rx.menu.trigger(rx.button("drop down menu")),
         rx.menu.content(
             rx.menu.item("Edit", shortcut="⌘ E"),
             rx.menu.item("Share"),

--- a/pcweb/pages/docs/component.py
+++ b/pcweb/pages/docs/component.py
@@ -191,7 +191,7 @@ def prop_docs(prop: Prop, prop_dict, component) -> list[rx.Component]:
     from typing import Literal, _GenericAlias
 
     def render_select(prop):
-        if not rx.utils.types._issubclass(component, (RadixThemesComponent, RadixPrimitiveComponent)) or component.__name__ in ["Theme", "ThemePanel"]:
+        if not rx.utils.types._issubclass(component, (RadixThemesComponent, RadixPrimitiveComponent)) or component.__name__ in ["Theme", "ThemePanel", "DrawerRoot", "DrawerTrigger", "DrawerOverlay", "DrawerPortal", "DrawerContent", "DrawerClose"]:
             return rx.fragment()
         try:
             type_ = rx.utils.types.get_args(prop.type_)[0]
@@ -486,7 +486,7 @@ def generate_props(src, component, comp):
         if f"{component.__name__}" in comp.metadata:
             comp = eval(comp.metadata[component.__name__])(**prop_dict)
         
-        elif not rx.utils.types._issubclass(component, (RadixThemesComponent, RadixPrimitiveComponent)) or component.__name__ in ["Theme", "ThemePanel"]:
+        elif not rx.utils.types._issubclass(component, (RadixThemesComponent, RadixPrimitiveComponent)) or component.__name__ in ["Theme", "ThemePanel",  "DrawerRoot", "DrawerTrigger", "DrawerOverlay", "DrawerPortal", "DrawerContent", "DrawerClose"]:
             comp = rx.fragment()
 
         else:

--- a/pcweb/pages/docs/gallery.py
+++ b/pcweb/pages/docs/gallery.py
@@ -327,7 +327,7 @@ def add_item(category):
             ),
         ),
         rx.chakra.hstack(
-            rx.chakra.heading(category["name"], style={"fontSize": "1em"}),
+            rx.heading(category["name"], style={"fontSize": "1em"}),
             rx.chakra.spacer(),
             rx.chakra.hstack(
                 rx.link(
@@ -446,7 +446,7 @@ def sidebar():
     return rx.chakra.box(
         rx.chakra.vstack(
             rx.chakra.vstack(
-                rx.chakra.heading(
+                rx.heading(
                     "Filters",
                     padding_left=".5em",
                 ),
@@ -509,8 +509,8 @@ def gallery_with_no_sidebar():
 def gallery() -> rx.Component:
     return rx.chakra.vstack(
         rx.chakra.vstack(
-            rx.chakra.heading("Gallery", font_size="2em"),
-            rx.chakra.text(
+            rx.heading("Gallery", font_size="2em"),
+            rx.text(
                 "Browse our growing library of example apps. Use them as they are, right out of the box, or customize them to suit your needs.",
                 color="#342E5C",
                 font_size="1.2em",

--- a/pcweb/pages/docs/library.py
+++ b/pcweb/pages/docs/library.py
@@ -18,6 +18,7 @@ def component_grid():
                             rx.utils.format.to_title_case(c[0]),
                             href=get_component_link(category, c),
                             font_size="1em",
+                            color=rx.color("mauve", 12)
                         )
                         for c in component_list[category]
                     ],
@@ -28,7 +29,7 @@ def component_grid():
                 box_shadow="rgba(50, 50, 93, 0.25) 0px 2px 5px -1px, rgba(0, 0, 0, 0.3) 0px 1px 3px -1px",
                 border_radius="1em",
                 bg_color="white",
-                padding=5,
+                padding="2em",
                 _hover={
                     "box_shadow": "rgba(38, 57, 77, .3) 0px 20px 30px -10px",
                 },

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -209,11 +209,16 @@ def breadcrumb(path):
 
     # Iteratively build the href for each segment
     for i in range(len(segments)):
-        # Construct href by joining the segments up to the current one
-        href = '/' + '/'.join(segments[:i+1]).lower()
+        # Check if the current segment is the last one
+        is_last_segment = i == len(segments) - 1
 
-        # Create the breadcrumb item
-        breadcrumb_item = rx.link(segments[i], href=href, color=rx.color("mauve", 9))
+        # Construct href by joining the segments up to the current one, only for the last segment
+        if is_last_segment:
+            href = '/' + '/'.join(segments[:i+1]).lower()
+            breadcrumb_item = rx.link(segments[i], href=href, color=rx.color("mauve", 9))
+        else:
+            # For non-last segments, create text items instead of links
+            breadcrumb_item = rx.text(segments[i], color=rx.color("mauve", 9))
 
         # Add the breadcrumb item to the list
         breadcrumbs.append(breadcrumb_item)
@@ -224,6 +229,7 @@ def breadcrumb(path):
 
     # Return the list of breadcrumb items with separators
     return rx.flex(*breadcrumbs, spacing="2")
+
 
 def get_headings(comp):
      """Get the strings from markdown component."""

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -209,19 +209,8 @@ def breadcrumb(path):
 
     # Iteratively build the href for each segment
     for i in range(len(segments)):
-        # Check if the current segment is the last one
-        is_last_segment = i == len(segments) - 1
-
-        # Construct href by joining the segments up to the current one, only for the last segment
-        if is_last_segment:
-            href = '/' + '/'.join(segments[:i+1]).lower()
-            breadcrumb_item = rx.link(segments[i], href=href, color=rx.color("mauve", 9))
-        else:
-            # For non-last segments, create text items instead of links
-            breadcrumb_item = rx.text(segments[i], color=rx.color("mauve", 9))
-
         # Add the breadcrumb item to the list
-        breadcrumbs.append(breadcrumb_item)
+        breadcrumbs.append(rx.text(segments[i], color=rx.color("mauve", 9)))
 
         # If it's not the last segment, add a separator
         if i < len(segments) - 1:


### PR DESCRIPTION
```python
rx.drawer.root(
        rx.drawer.trigger(
            rx.button("Open Drawer")    
        ),
        rx.drawer.overlay(),
        rx.drawer.portal(
            rx.drawer.content(
                rx.flex(
                    rx.drawer.close(rx.box(rx.button("Close"))),
                    align_items="start",
                    direction="column",
                ),
                top="auto",
                right="auto",
                height="100%",
                width="20em",
                padding="2em",
                background_color=rx.color("green", 3)
            )
        ),
        direction="left",
)
```
These are some basic docs for the drawer component. 

Some problems to address before we merge the following code above causes an error because the drawer component is treating background_color as a prop when it should be a style prop. Also any radix component inside of the drawer.content loses its styling from the theme

Needs this pr to run https://github.com/reflex-dev/reflex/pull/2604