### PR TITLE
align_items="center" for vstack and hstack

### DIFF
--- a/pcweb/styles/styles.py
+++ b/pcweb/styles/styles.py
@@ -60,6 +60,8 @@ BASE_STYLE = {
     },
     rx.divider: {"margin_bottom": "1em", "margin_top": "0.5em"},
     rx.link: {"text_decoration": "none", "_hover": {}},
+    rx.vstack: {"align_items": "center"},
+    rx.hstack: {"align_items": "center"},
     rx.chakra.divider: {"margin_bottom": "1em", "margin_top": "0.5em"},
     rx.chakra.code: {"color": "#1F1944", "bg": "#EAE4FD"},
     rx.chakra.alert: {


### PR DESCRIPTION
Some of the example demos were mis-aligned because vstack and hstack do not center by default in 0.4.0