### PR TITLE
[REF-1448] Improve upload and download docs for 0.4.0

### DIFF
--- a/docs/api-reference/special_events.md
+++ b/docs/api-reference/special_events.md
@@ -81,7 +81,12 @@ Download a file at a given path.
 Parameters:
 
 - `url`: The URL of the file to be downloaded.
+- `data`: The data to be downloaded. Should be `str` or `bytes`, `data:` URI, `PIL.Image`, or any state Var (to be converted to JSON).
 - `filename`: The desired filename of the downloaded file.
+
+```md alert
+`url` and `data` args are mutually exclusive, and at least one of them must be provided.
+```
 
 ```python demo
 rx.button("Download", on_click=rx.download(url="/reflex_logo.png", filename="different_name_logo.png"))

--- a/docs/assets/referencing_assets.md
+++ b/docs/assets/referencing_assets.md
@@ -6,6 +6,13 @@ import reflex as rx
 
 Static files such as images and stylesheets can be placed in `"assets/"` folder of the project. These files can be referenced within your app.
 
+```md alert
+# Assets are copied during the build process.
+
+Any files placed within the `assets/` folder at runtime will not be available to the app
+when running in production mode. The `assets/` folder should only be used for static files.
+```
+
 ## Referencing Assets
 
 To reference an image in the `"assets/"` simply pass the relative path as a prop.
@@ -21,6 +28,11 @@ Then you can display it using a `rx.image` component:
 
 ```python demo
 rx.image(src="/Reflex.svg", width="5em")
+```
+
+```md alert
+Always prefix the asset path with a forward slash `/` to reference the asset from the root of the project,
+or it may not display correctly on non-root pages.
 ```
 
 ## Favicon

--- a/docs/assets/upload_and_download_files.md
+++ b/docs/assets/upload_and_download_files.md
@@ -16,7 +16,7 @@ If you want to let the users of your app download files from your server to thei
 
 ### With a regular link
 
-For some basic usage, simply providing the path to your resource in a `rx.link` will work, and clicking the link will download the resource.
+For some basic usage, simply providing the path to your resource in a `rx.link` will work, and clicking the link will download or display the resource.
 
 ```python demo
 rx.link("Download", href="/reflex_logo.png")
@@ -24,7 +24,9 @@ rx.link("Download", href="/reflex_logo.png")
 
 ### With `rx.download` event
 
-In case a simple link is not enough, or if you want to trigger downloads from the backend, you can use `rx.download` event.
+Using the `rx.download` event will always prompt the browser to download the file, even if it could be displayed in the browser.
+
+The `rx.download` event also allows the download to be triggered from another backend event handler.
 
 ```python demo
 rx.button(
@@ -33,7 +35,7 @@ rx.button(
 )
 ```
 
-`rx.download` also let you specify a name for the file that will be downloaded, if you want it to be different from the name on the server side.
+`rx.download` lets you specify a name for the file that will be downloaded, if you want it to be different from the name on the server side.
 
 ```python demo
 rx.button(
@@ -45,7 +47,28 @@ rx.button(
 )
 ```
 
-Reference page for `rx.download` [here]({api_reference.special_events.path}).
+If the data to download is not already available at a known URL, pass the `data` directly to the `rx.download` event from the backend.
+
+```python demo exec
+import random
+
+class DownloadState(rx.State):
+    def download_random_data(self):
+        return rx.download(
+            data=",".join([str(random.randint(0, 100)) for _ in range(10)]),
+            filename="random_numbers.csv"
+        )
+
+def download_random_data_button():
+    return rx.button(
+        "Download random numbers",
+        on_click=DownloadState.download_random_data
+    )
+```
+
+The `data` arg accepts `str` or `bytes` data, a `data:` URI, `PIL.Image`, or any state Var. If the Var is not already a string, it will be converted to a string using `JSON.stringify`. This allows complex state structures to be offered as JSON downloads.
+
+Reference page for `rx.download` [here]({api_reference.special_events.path}#rx.download).
 
 ## Upload
 
@@ -63,4 +86,4 @@ def index():
     )
 ```
 
-For detailed informations, see the reference page of the component [here]({library.forms.upload.path}).
+For detailed information, see the reference page of the component [here]({library.forms.upload.path}).

--- a/docs/library/forms/upload.md
+++ b/docs/library/forms/upload.md
@@ -17,13 +17,14 @@ You can upload files by clicking on the component or by dragging and dropping fi
 ```python demo
 rx.upload(
     rx.text("Drag and drop files here or click to select files"),
+    id="my_upload",
     border="1px dotted rgb(107,99,246)",
     padding="5em",
 )
 ```
 
-Selecting a file will add it to the browser's file list, which can be rendered on the frontend using the `rx.selected_files` special Var.
-To clear the selected files, you can use another special Var `rx.clear_selected_files` as an event handler.
+Selecting a file will add it to the browser's file list, which can be rendered on the frontend using the `rx.selected_files(id)` special Var.
+To clear the selected files, you can use another special Var `rx.clear_selected_files(id)` as an event handler.
 To upload the file, you need to bind an event handler and pass the file list.
 
 A full example is shown below.
@@ -47,10 +48,10 @@ class State(rx.State):
         \"""
         for file in files:
             upload_data = await file.read()
-            outfile = rx.get_asset_path(file.filename)
+            outfile = rx.get_upload_dir() / file.filename
 
             # Save the file.
-            with open(outfile, "wb") as file_object:
+            with outfile.open("wb") as file_object:
                 file_object.write(upload_data)
 
             # Update the img var.
@@ -68,19 +69,20 @@ def index():
                 rx.button("Select File", color=color, bg="white", border=f"1px solid \{color}"),
                 rx.text("Drag and drop files here or click to select files"),
             ),
+            id="upload1",
             border=f"1px dotted \{color}",
             padding="5em",
         ),
-        rx.hstack(rx.foreach(rx.selected_files, rx.text)),
+        rx.hstack(rx.foreach(rx.selected_files("upload1"), rx.text)),
         rx.button(
             "Upload",
-            on_click=lambda: State.handle_upload(rx.upload_files()),
+            on_click=State.handle_upload(rx.upload_files(upload_id="upload1")),
         ),
         rx.button(
             "Clear",
-            on_click=rx.clear_selected_files,
+            on_click=rx.clear_selected_files("upload1"),
         ),
-        rx.foreach(State.img, lambda img: rx.image(src=img)),
+        rx.foreach(State.img, lambda img: rx.image(src=rx.get_upload_url(img))),
         padding="5em",
     )
 ```
@@ -103,10 +105,10 @@ class State(rx.State):
         \"""
         for file in files:
             upload_data = await file.read()
-            outfile = f".web/public/\{file.filename}"
+            outfile = rx.get_upload_dir() / file.filename
 
             # Save the file.
-            with open(outfile, "wb") as file_object:
+            with outfile.open("wb") as file_object:
                 file_object.write(upload_data)
 
             # Update the img var.
@@ -124,6 +126,7 @@ def index():
                 rx.button("Select File", color=color, bg="white", border=f"1px solid \{color}"),
                 rx.text("Drag and drop files here or click to select files"),
             ),
+            id="upload2",
             multiple=True,
             accept = {
                 "application/pdf": [".pdf"],
@@ -141,13 +144,13 @@ def index():
         ),
         rx.button(
             "Upload",
-            on_click=lambda: State.handle_upload(rx.upload_files()),
+            on_click=State.handle_upload(rx.upload_files(upload_id="upload2")),
         ),
         rx.chakra.responsive_grid(
             rx.foreach(
                 State.img,
                 lambda img: rx.vstack(
-                    rx.image(src=img),
+                    rx.image(src=rx.get_upload_url(img)),
                     rx.text(img),
                 ),
             ),
@@ -158,8 +161,94 @@ def index():
     )
 ```
 
+## Handling the Upload
+
 Your event handler should be an async function that accepts a single argument,
 `files: list[UploadFile]`, which will contain [FastAPI UploadFile](https://fastapi.tiangolo.com/tutorial/request-files) instances.
 You can read the files and save them anywhere as shown in the example.
 
 In your UI, you can bind the event handler to a trigger, such as a button `on_click` event, and pass in the files using `rx.upload_files()`.
+
+### Saving the File
+
+By convention, Reflex provides the function `rx.get_upload_dir()` to get the directory where uploaded files may be saved. The upload dir comes from the environment variable `REFLEX_UPLOADED_FILES_DIR`, or `./uploaded_files` if not specified.
+
+The backend of your app will mount this uploaded files directory on `/_upload` without restriction. Any files uploaded via this mechanism will automatically be publicly accessible. To get the URL for a file inside the upload dir, use the `rx.get_upload_url(filename)` function in a frontend component.
+
+```md alert
+When using the Reflex hosting service, the uploaded files directory is not persistent and will be cleared on every deployment.
+
+For persistent storage of uploaded files, it is recommended to use an external service, such as S3.
+```
+
+## Cancellation
+
+The `id` provided to the `rx.upload` component can be passed to the special event handler `rx.cancel_upload(id)` to stop uploading on demand. Cancellation can be triggered directly by a frontend event trigger, or it can be returned from a backend event handler.
+
+## Progress
+
+The `rx.upload_files` special event arg also accepts an `on_upload_progress` event trigger which will be fired about every second during the upload operation to report the progress of the upload. This can be used to update a progress bar or other UI elements to show the user the progress of the upload.
+
+```python
+class UploadExample(rx.State):
+    uploading: bool = False
+    progress: int = 0
+    total_bytes: int = 0
+
+    async def handle_upload(self, files: list[rx.UploadFile]):
+        for file in files:
+            self.total_bytes += len(await file.read())
+
+    def handle_upload_progress(self, progress: dict):
+        self.uploading = True
+        self.progress = round(progress["progress"] * 100)
+        if self.progress >= 100:
+            self.uploading = False
+
+    def cancel_upload(self):
+        self.uploading = False
+        return rx.cancel_upload("upload3")
+
+
+def upload_form():
+    return rx.vstack(
+        rx.upload(
+            rx.text("Drag and drop files here or click to select files"),
+            id="upload3",
+            border="1px dotted rgb(107,99,246)",
+            padding="5em",
+        ),
+        rx.vstack(rx.foreach(rx.selected_files("upload3"), rx.text)),
+        rx.progress(value=UploadExample.progress, max=100),
+        rx.cond(
+            ~UploadExample.uploading,
+            rx.button(
+                "Upload",
+                on_click=UploadExample.handle_upload(
+                    rx.upload_files(
+                        upload_id="upload3",
+                        on_upload_progress=UploadExample.handle_upload_progress,
+                    ),
+                ),
+            ),
+            rx.button("Cancel", on_click=UploadExample.cancel_upload),
+        ),
+        rx.text("Total bytes uploaded: ", UploadExample.total_bytes),
+        align="center",
+    )
+```
+
+The `progress` dictionary contains the following keys:
+
+```javascript
+\{
+    'loaded': 36044800,
+    'total': 54361908,
+    'progress': 0.6630525183185255,
+    'bytes': 20447232,
+    'rate': None,
+    'estimated': None,
+    'event': \{'isTrusted': True},
+    'upload': True
+}
+```

--- a/pcweb/flexdown.py
+++ b/pcweb/flexdown.py
@@ -59,9 +59,11 @@ class AlertBlock(flexdown.blocks.MarkdownBlock):
                     ("error", rx.icon(tag="ban")),
                 ),
             ),
-            rx.callout.text(
+            # This is a div to avoid <p> in a <p> issues.
+            rx.el.div(
                 markdown(title + " ") if title else "",
                 markdown(content),
+                class_name="rt-CalloutText",
             ),
             color_scheme=color,
             background_color = f"{rx.color(color, 3)}",


### PR DESCRIPTION
Had to do a weird hack inside the `AlertBlock` because the `rx.callout.text` actually renders as a `<p>` element, so we get a hydration error when the markdown inside the alert renders to a nested `<p>` element. Forcing a `<div>` with the `rt-CalloutText` class seems to work fine, not sure why this was only hitting on a few of my pages though when alerts are used correctly throughout the site.