### PR TITLE
Fixed broken Chakra Input Python Demo Exec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 **/.web
 *.db
 *.py[cod]
-*.web
 *.zip
 .idea
 .venv/

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 **/.web
 *.db
 *.py[cod]
+*.web
 *.zip
 .idea
 .venv/

--- a/blog/2024-02-16-reflex-v0.4.0.md
+++ b/blog/2024-02-16-reflex-v0.4.0.md
@@ -47,7 +47,7 @@ pip install --upgrade reflex
 Since the core components have changed from Radix, existing apps will need to run the migration script to keep using Chakra.
 
 ```text
-reflex scripts keep-chakra
+reflex script keep-chakra
 ```
 
 This will convert all components in your app to the new namespace.

--- a/docs/library/chakra/forms/input.md
+++ b/docs/library/chakra/forms/input.md
@@ -87,10 +87,10 @@ rx.chakra.password()
  ```python demo exec
  class InputFormState(rx.State):
 
-    form_data: dict = \{}
+    form_data: dict = {}
 
     def handle_submit(self, form_data: dict):
-        \"""Handle the form submit.\"""
+        """Handle the form submit."""
         self.form_data = form_data
         return [rx.chakra.set_value(field_id, "") for field_id in form_data]
 

--- a/docs/library/chakra/forms/input.md
+++ b/docs/library/chakra/forms/input.md
@@ -81,20 +81,17 @@ We also provide a `rx.chakra.password` component as a shorthand for the password
 rx.chakra.password()
 ```
 
- You can also use forms in combination with inputs.
- This is useful for collecting multiple values with a single event handler and automatically supporting `Enter` key submit functionality that desktop users expect.
+You can also use forms in combination with inputs.
+This is useful for collecting multiple values with a single event handler and automatically supporting `Enter` key submit functionality that desktop users expect.
 
- ```python demo exec
- class InputFormState(rx.State):
-
+```python demo exec
+class InputFormState(rx.State):
     form_data: dict = {}
 
     def handle_submit(self, form_data: dict):
         """Handle the form submit."""
         self.form_data = form_data
-        return [rx.chakra.set_value(field_id, "") for field_id in form_data]
-
-
+    
 def input_form_example():
     return rx.chakra.vstack(
         rx.chakra.form(
@@ -109,4 +106,5 @@ def input_form_example():
         rx.chakra.heading("Results"),
         rx.chakra.text(InputFormState.form_data.to_string()),
     )
- ```
+```
+


### PR DESCRIPTION
Fixed rendering issues on the Chakra Input forms documentation page.
Link of the Page: https://reflex.dev/docs/library/chakra/forms/input/


https://github.com/reflex-dev/reflex-web/assets/111660265/c8b7d411-e19d-459f-ac9e-a4916764fd05

