### PR TITLE
Fix audio doc

### DIFF
--- a/docs/library/media/audio.md
+++ b/docs/library/media/audio.md
@@ -13,9 +13,9 @@ The audio component can display an audio given an src path as an argument. This 
 
 ```python demo
 rx.audio(
-    url="https://www.learningcontainer.com/wp-content/uploads/2020/02/Kalimba.mp3", 
+    url="https://www.learningcontainer.com/wp-content/uploads/2020/02/Kalimba.mp3",
     width="400px",
-    height="auto"
+    height="32px",
 )
 ```
 


### PR DESCRIPTION
For certain chrome browser, the `height="auto"` makes the audio control into a line and not visible.