### PR TITLE
Remove description meta - let it autogenerate

### DIFF
--- a/pcweb/pcweb.py
+++ b/pcweb/pcweb.py
@@ -54,7 +54,6 @@ for route in routes:
         route.component,
         route.path,
         route.title,
-        description="Performant, customizable web apps in pure Python. Deploy in seconds.",
         image="/previews/index_preview.png",
     )
 


### PR DESCRIPTION
Search engines like Google will auto-generate descriptions for pages better than we can do it at the moment - let's rely on auto descriptions for now.