### PR TITLE
Cleanup progress bar examples in docs

### DIFF
--- a/docs/library/datadisplay/progress-ll.md
+++ b/docs/library/datadisplay/progress-ll.md
@@ -1,23 +1,57 @@
 ---
 components:
-    - rx.radix.primitives.progress.root
-    - rx.radix.primitives.progress.indicator
-
-Progress: |
-    lambda **props: rx.progress(value=50, width="100%", **props)
-
-ProgressIndicator: |
-    lambda **props: rx.progress.root(
-        rx.progress.indicator(value=50, **props),
-        width="100%", 
-    )
+    - rx.progress.root
+    - rx.progress.indicator
 ---
 
 ```python exec
 import reflex as rx
+```
+
+# Progress
+
+Progress is used to display the progress status for a task that takes a long time or consists of several steps.
+
+## Basic Example
+
+`rx.progress.root` exposes the `width`, `height`, and `radius` props.
+
+`rx.progress.indicator` accepts the `value` prop to set the progress value with
+the `max` prop specifying the value at which the progress is considered
+complete. Max should always be specified, because it defaults to `0`.
+
+The color of the bar may be set to a radix color via the `color_scheme` prop.
+Alternatively, the `background` or `background_color` can be specified with any
+valid CSS background.
+
+```python demo
+rx.vstack(
+    rx.progress.root(
+        rx.progress.indicator(value=30, max=100, color_scheme="tomato"),
+        radius="none",
+        height="10px",
+    ),
+    rx.progress.root(
+        rx.progress.indicator(value=50, max=100, color_scheme="amber"),
+        radius="medium",
+        height="15px",
+    ),
+    rx.progress.root(
+        rx.progress.indicator(value=80, max=100, color_scheme="green"),
+        radius="full",
+        height="20px",
+    ),
+    gap="1em",
+    min_width=["10em", "20em"],
+)
+```
+
+For a dynamic progress, you can assign a state variable to the `value` prop instead of a constant value.
+
+```python demo exec
 import asyncio
 
-class ProgressState(rx.State):
+class ProgressState2(rx.State):
     value: int = 0
 
     @rx.background
@@ -28,28 +62,18 @@ class ProgressState(rx.State):
             await asyncio.sleep(0.1)
             async with self:
                 self.value += 1
-```
 
-# Progress
 
-Progress is used to display the progress status for a task that takes a long time or consists of several steps.
-
-## Basic Example
-
-`rx.progress` expect the `value` prop to set the progress value.
-
-```python demo
-rx.vstack(
-    rx.progress(value=0, width="100%"),
-    rx.progress(value=50, width="100%"),
-    rx.progress(value=100, width="100%"),
-    gap="1em",
-    min_width=["10em", "20em"],
-)
-```
-
-For a dynamic progress, you can assign a state variable to the `value` prop instead of a constant value.
-
-```python demo
-rx.hstack(rx.progress(value=ProgressState.value, width="100%"), rx.button("Start", on_click=ProgressState.start_progress))
+def live_progress():
+    return rx.hstack(
+        rx.progress.root(
+            rx.progress.indicator(
+                value=ProgressState2.value,
+                max=100,
+                background="linear-gradient(90deg, rgba(131,58,180,1) 0%, rgba(253,29,29,1) 50%, rgba(252,176,69,1) 100%)",
+            ), 
+        ),
+        rx.button("Start", on_click=ProgressState2.start_progress),
+        width="10em"
+    )
 ```

--- a/docs/library/datadisplay/progress.md
+++ b/docs/library/datadisplay/progress.md
@@ -1,13 +1,44 @@
 ---
 components:
-    - rx.radix.primitives.progress.root
+    - rx.progress
+    - rx.progress.root
+    - rx.progress.indicator
 
 Progress: |
-    lambda **props: rx.progress(value=50, width="100%", **props)
+    lambda **props: rx.progress(value=50, **props)
+
+ProgressRoot: |
+    lambda **props: rx.progress.root(rx.progress.indicator(value=50, max=100), **props)
+
+ProgressIndicator: |
+    lambda **props: rx.progress.root(rx.progress.indicator(value=50, max=100, **props))
 ---
 
 ```python exec
 import reflex as rx
+```
+
+# Progress
+
+Progress is used to display the progress status for a task that takes a long time or consists of several steps.
+
+## Basic Example
+
+`rx.progress` expects the `value` prop to set the progress value.
+
+```python demo
+rx.vstack(
+    rx.progress(value=0),
+    rx.progress(value=50),
+    rx.progress(value=100),
+    gap="1em",
+    min_width=["10em", "20em"],
+)
+```
+
+For a dynamic progress, you can assign a state variable to the `value` prop instead of a constant value.
+
+```python demo exec
 import asyncio
 
 class ProgressState(rx.State):
@@ -21,32 +52,12 @@ class ProgressState(rx.State):
             await asyncio.sleep(0.1)
             async with self:
                 self.value += 1
-```
 
-# Progress
 
-Progress is used to display the progress status for a task that takes a long time or consists of several steps.
-
-## Basic Example
-
-`rx.progress` expect the `value` prop to set the progress value.
-
-```python demo
-rx.vstack(
-    rx.progress(value=0, width="100%"),
-    rx.progress(value=50, width="100%"),
-    rx.progress(value=100, width="100%"),
-    gap="1em",
-    min_width=["10em", "20em"],
-)
-```
-
-For a dynamic progress, you can assign a state variable to the `value` prop instead of a constant value.
-
-```python demo
-rx.hstack(
-    rx.progress(value=ProgressState.value, width="100%"), 
-    rx.button("Start", on_click=ProgressState.start_progress),
-    width="10em"
-)
+def live_progress():
+    return rx.hstack(
+        rx.progress(value=ProgressState.value), 
+        rx.button("Start", on_click=ProgressState.start_progress),
+        width="10em"
+    )
 ```


### PR DESCRIPTION
## Fix interactive docs

https://github.com/reflex-dev/reflex-web/assets/1524005/ab9884cc-0c13-4e6d-9c34-8a8d1d987574

## Make the low level examples a bit more interesting.

https://github.com/reflex-dev/reflex-web/assets/1524005/1f32e613-cd9c-4edf-a810-a9f40e323f60

