### PR TITLE
navbar: remove default for `sidebar` (rx.memo)

### DIFF
--- a/pcweb/components/navbar/navbar.py
+++ b/pcweb/components/navbar/navbar.py
@@ -128,7 +128,7 @@ def navigation_section():
 
 
 @rx.memo
-def navbar(sidebar: rx.Component = None) -> rx.Component():
+def navbar(sidebar: rx.Component) -> rx.Component:
     return rx.flex(
         rx.link(
             rx.box(


### PR DESCRIPTION
In py3.10, having a `None` default makes `get_type_hints` wrap the annotation in a `typing.Optional`, but the custom component `__init__` function determines whether to include imports/hooks based on the type. Since `Optional` is not a subclass of `Component`, the prop var was not correctly carrying the VarData from the component instance.

This fix unbreaks reflex-web (and also fixes the busted return type annotation while we're here).

A subsequent fix into reflex will make the serialization of CustomComponent props depend on the type of the value being passed rather than relying on correct annotations.