### PR TITLE
requirements.txt: upgrade psycopg2-binary to 2.9.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 email-validator==1.3.0
 black==23.10.0
 pandas>=1.5.3
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.9
 plotly-express==0.4.1
 googletrans-py==4.0.0
 typesense==0.14.0


### PR DESCRIPTION
This adds py3.12 support on macos