### PR TITLE
Fix overlay z-index issue (REF-2346)

### DIFF
--- a/docs/library/overlay/drawer.md
+++ b/docs/library/overlay/drawer.md
@@ -23,7 +23,9 @@ rx.drawer.root(
         rx.drawer.trigger(
             rx.button("Open Drawer")    
         ),
-        rx.drawer.overlay(),
+        rx.drawer.overlay(
+            z_index="5"
+        ),
         rx.drawer.portal(
             rx.drawer.content(
                 rx.flex(


### PR DESCRIPTION
The z-index was not set on the overlay example which made the overlay background fall behind the markdown example code. This fix resolves that issue.

Note: there's still a strange `z_index:50px` attribute in the overlay that both has a wrong case (underscore vs dash) and a value that is in pixels when it shouldn't be