### PR TITLE
Dark mode adjustments for docpages.

### DIFF
--- a/pcweb/components/navbar/buttons/style.py
+++ b/pcweb/components/navbar/buttons/style.py
@@ -3,7 +3,7 @@ import reflex as rx
 button_style = {
     "border_radius": "50px",
     "border": f"1px solid {rx.color('mauve', 4)}",
-    "background": f"1px solid {rx.color('mauve', 2)}",
+    "background": rx.color('mauve', 2),
     "box_shadow": "0px 3px 7px -4px rgba(21, 18, 44, 0.15)",
     "padding": "7px 12px 7px 12px",
     "align_items": "center",

--- a/pcweb/components/navbar/navbar.py
+++ b/pcweb/components/navbar/navbar.py
@@ -9,7 +9,7 @@ from .state import NavbarState
 
 def resource_header(text):
     return rx.text(
-        text, color=rx.color("mauve", 12), padding_bottom="10px", font_weight="600"
+        text, color=rx.color_mode_cond(rx.color("mauve", 12), rx.color("mauve", 10)), padding_bottom="10px", font_weight="600"
     )
 
 
@@ -133,7 +133,8 @@ def resources_section():
                     ),
                     direction="column",
                     background_color=rx.color("mauve", 3),
-                    border_left=f"1px solid {rx.color('mauve', 4)}",
+
+                    border_left=rx.color_mode_cond(f"1px solid {rx.color('mauve', 4)};",f"1px solid {rx.color('mauve', 3)};"),
                     align_items="start",
                     height="200px",
                     padding_top="20px",
@@ -145,8 +146,7 @@ def resources_section():
                 spacing="6",
             ),
             border=f"1px solid {rx.color('mauve', 4)}",
-            # background_color = rx.color("mauve", 2),
-            background="#FFF",
+            background=rx.color_mode_cond("#FFF", rx.color("mauve", 3)),
             max_width="1000px",
             height="200px",
             padding="0",
@@ -196,7 +196,7 @@ def navbar(sidebar: rx.Component) -> rx.Component:
                 search_bar(),
                 github(),
                 #product_hunt(),
-                rx.divider(size="2", color="mauve", orientation="vertical"),
+                rx.divider(size="2", color=rx.color("mauve"), orientation="vertical"),
                 rx.box(
                     discord(),
                     display=["none", "none", "none", "none", "flex", "flex"],
@@ -208,7 +208,9 @@ def navbar(sidebar: rx.Component) -> rx.Component:
                 spacing="3",
                 align_items="center",
             ),
-            background="rgba(255,255,255, 0.8)",
+            # color cond
+            background=rx.color_mode_cond(rx.color("mauve", 3), rx.color("mauve", 9)),
+            opacity=0.9,
             backdrop_filter="blur(10px)",
             border_bottom=f"1px solid {rx.color('mauve', 4)};",
             width="100%",

--- a/pcweb/components/navbar/navbar.py
+++ b/pcweb/components/navbar/navbar.py
@@ -73,7 +73,7 @@ def resources_section():
     return rx.hover_card.root(
         rx.hover_card.trigger(
             rx.flex(
-                rx.text("Resources", color=rx.color("mauve", 11)),
+                rx.text("Resources", color=rx.color_mode_cond(rx.color("mauve", 11), rx.color("mauve", 10))),
                 rx.icon(tag="chevron_down", color=rx.color("mauve", 11), size=18),
                 align_items="center",
                 _hover={
@@ -158,13 +158,13 @@ def navigation_section():
     return rx.box(
         rx.flex(
             rx.link(
-                rx.text("Docs", color=rx.color("mauve", 11)),
-                href="/docs/getting-started/introduction/",
-            ),
-            rx.link(rx.text("Blog", color=rx.color("mauve", 11)), href="/blog"),
-            rx.link(
-                rx.text("Gallery", color=rx.color("mauve", 11)), href="/docs/gallery"
-            ),
+                rx.text("Docs", color=rx.color_mode_cond(rx.color("mauve", 11), rx.color("mauve", 10))),
+                    href="/docs/getting-started/introduction/",
+                ),
+                rx.link(rx.text("Blog", color=rx.color_mode_cond(rx.color("mauve", 11), rx.color("mauve", 10))), href="/blog"),
+                rx.link(
+                    rx.text("Gallery", color=rx.color_mode_cond(rx.color("mauve", 11), rx.color("mauve", 10))), href="/docs/gallery"
+                    ),
             resources_section(),
             spacing="5",
         ),
@@ -179,11 +179,19 @@ def navbar(sidebar: rx.Component) -> rx.Component:
         rx.flex(
             rx.link(
                 rx.box(
-                    rx.image(
-                        src="/logos/light/reflex.svg",
-                        alt="Reflex Logo",
-                        height="20px",
-                        justify="start",
+                    rx.color_mode_cond(
+                        rx.image(
+                            src="/logos/light/reflex.svg",
+                            alt="Reflex Logo",
+                            height="20px",
+                            justify="start",
+                        ),
+                        rx.image(
+                            src="/logos/dark/reflex.svg",
+                            alt="Reflex Logo",
+                            height="20px",
+                            justify="start",
+                        )
                     )
                 ),
                 href="/",
@@ -195,7 +203,6 @@ def navbar(sidebar: rx.Component) -> rx.Component:
             rx.flex(
                 search_bar(),
                 github(),
-                #product_hunt(),
                 rx.divider(size="2", color=rx.color("mauve"), orientation="vertical"),
                 rx.box(
                     discord(),
@@ -208,8 +215,7 @@ def navbar(sidebar: rx.Component) -> rx.Component:
                 spacing="3",
                 align_items="center",
             ),
-            # color cond
-            background=rx.color_mode_cond(rx.color("mauve", 3), rx.color("mauve", 9)),
+            background=rx.color("mauve", 3),
             opacity=0.9,
             backdrop_filter="blur(10px)",
             border_bottom=f"1px solid {rx.color('mauve', 4)};",

--- a/pcweb/components/sidebar/sidebar.py
+++ b/pcweb/components/sidebar/sidebar.py
@@ -243,7 +243,7 @@ def sidebar_category(name, icon, color, index):
         rx.button(
             rx.icon(
                 tag=icon,
-                color=rx.color(color, 1),
+                color="#FFFFFF",
                 size=20,
             ),
             height="30px",
@@ -263,7 +263,7 @@ def sidebar_category(name, icon, color, index):
         on_click=lambda: SidebarState.set_sidebar_index(index),
         background=rx.cond(
             SidebarState.sidebar_index == index,
-            "#F5EFFE",
+            rx.color_mode_cond(rx.color("accent", 3), "#440150"), #dark mode color is hard-coded for now
             "transparent",
         ),
         align_items="center",

--- a/pcweb/pages/docs/gallery.py
+++ b/pcweb/pages/docs/gallery.py
@@ -531,8 +531,6 @@ def gallery() -> rx.Component:
         ),
         max_width="80em",
         margin_x="auto",
-        margin_top="120px",
+        margin_top="115px",
         height="100%",
     )
-
-# fixme

--- a/pcweb/pages/docs/gallery.py
+++ b/pcweb/pages/docs/gallery.py
@@ -531,6 +531,8 @@ def gallery() -> rx.Component:
         ),
         max_width="80em",
         margin_x="auto",
-        margin_top="80px",
+        margin_top="120px",
         height="100%",
     )
+
+# fixme

--- a/pcweb/templates/docpage/blocks/code.py
+++ b/pcweb/templates/docpage/blocks/code.py
@@ -37,7 +37,7 @@ def code_block(code: str, language: str):
         ),
         border_radius=styles.DOC_BORDER_RADIUS,
         border=f"2px solid {rx.color('mauve', 3)}",
-        background_color=f"{rx.color('mauve', 2)}",
+        background_color=rx.color('mauve', 2),
         position="relative",
         margin_bottom="1em",
         margin_top="1em",

--- a/pcweb/templates/docpage/blocks/code.py
+++ b/pcweb/templates/docpage/blocks/code.py
@@ -29,6 +29,8 @@ def code_block(code: str, language: str):
             color=f"2px solid {rx.color('mauve', 4)}",
             background="transparent",
             _hover={
+                "opacity": 0.5,
+                "cursor": "pointer",
                 "background": "transparent",
                 "color": f"2px solid {rx.color('violet', 4)}",
             },
@@ -88,6 +90,8 @@ def doccmdoutput(
                 color=rx.color("mauve", 4),
                 background="transparent",
                 _hover={
+                    "opacity": 0.5,
+                    "cursor": "pointer",
                     "background": "transparent",
                     "color": rx.color("violet", 4),
                 },

--- a/pcweb/templates/docpage/blocks/typography.py
+++ b/pcweb/templates/docpage/blocks/typography.py
@@ -30,7 +30,7 @@ def definition(title: str, *children) -> rx.Component:
 
 @rx.memo
 def text_comp(text: rx.Var[str]) -> rx.Component:
-    return rx.text(text, size="3", line_height="1.7", margin_bottom="1em")
+    return rx.text(text, size="3", line_height="1.7", margin_bottom="1em", color=rx.color("mauve", 10))
 
 
 @rx.memo

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -102,7 +102,8 @@ def docpage_footer(path: str):
             rx.flex(
                 rx.text(
                     "Did you find this useful?",
-                    color=rx.color("mauve", 12),
+                    color=rx.color("mauve", 10),
+                    weight="bold",
                     white_space="nowrap",
                 ),
                 rx.divider(size="4", orientation="vertical"),

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -502,7 +502,6 @@ def docpage(set_path: str | None = None, t: str | None = None) -> rx.Component:
                         display=["none", "none", "none", "none", "none", "flex"],
                         flex_shrink=0,
                     ),
-                    background=rx.color("mauve", 2),
                     max_width="110em",
                     margin_left="auto",
                     margin_right="auto",
@@ -511,7 +510,7 @@ def docpage(set_path: str | None = None, t: str | None = None) -> rx.Component:
                     min_height="100vh",
                     width="100%",
                 ),
-                background=rx.color("mauve", 2),
+                background=rx.color("mauve", 1),
                 width="100%",
                 justify="center",
             )

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -502,7 +502,7 @@ def docpage(set_path: str | None = None, t: str | None = None) -> rx.Component:
                         display=["none", "none", "none", "none", "none", "flex"],
                         flex_shrink=0,
                     ),
-                    background="#FFF",
+                    background=rx.color("mauve", 2),
                     max_width="110em",
                     margin_left="auto",
                     margin_right="auto",
@@ -511,7 +511,7 @@ def docpage(set_path: str | None = None, t: str | None = None) -> rx.Component:
                     min_height="100vh",
                     width="100%",
                 ),
-                background="#FFF",
+                background=rx.color("mauve", 2),
                 width="100%",
                 justify="center",
             )


### PR DESCRIPTION
<img width="1829" alt="Screenshot 2024-03-28 at 3 55 24 PM" src="https://github.com/reflex-dev/reflex-web/assets/159659100/ff4b6960-8d80-42de-9996-1ac0714aa063">
<img width="1821" alt="Screenshot 2024-03-28 at 3 57 30 PM" src="https://github.com/reflex-dev/reflex-web/assets/159659100/f4aca50f-ad51-4fc5-9372-e4ac24cae6d6">
Doesn't has to be merged, now. Save change for later. 