### PR TITLE
A potential fix(improvement) of the "sidebar doesn't stay open correctly" bug. 

### DIFF
--- a/pcweb/pages/docs/__init__.py
+++ b/pcweb/pages/docs/__init__.py
@@ -160,7 +160,7 @@ for doc in sorted(flexdown_docs):
     path = doc.split("/")[1:-1]
     title = rx.utils.format.to_snake_case(os.path.basename(doc).replace(".md", ""))
     title2 = to_title_case(title)
-    route = rx.utils.format.to_kebab_case(f"/{doc.replace('.md', '/')}")
+    route = rx.utils.format.to_kebab_case(f"/{doc.replace('.md', '')}")
     comp = get_component(doc, title)
 
     if path[0] == "library" and isinstance(library, Route):


### PR DESCRIPTION
The `sidebar_leaf` function in `sidebar.py` compares `item.link == url`, where the `url` has a '/' at the end and `item.link` does not, so the statement never evaluates to be true. I removed the trailing '/' when the `url`was passed in from the top level (`__init__.py`). This current fix resolves the issue for now. (In the "learn" section)

The Components and API Reference section still has some issues. (It is difficult to describe here, so I will open a new ticket and do a demo at the stand-up meeting.)

