### PR TITLE
Fix for TypeError in Upload Docs

### DIFF
--- a/docs/api-reference/special_events.md
+++ b/docs/api-reference/special_events.md
@@ -19,6 +19,20 @@ rx.button('Log', on_click=rx.console_log('Hello World!'))
 When triggered, this event logs a specified message to the browser's developer console.
 It's useful for debugging and monitoring the behavior of your application.
 
+## rx.scroll_to
+
+scroll to an element in the page
+
+```python demo
+rx.button(
+    "Scroll to download button",
+    on_click=rx.scroll_to("download button")
+    
+)
+```
+
+When this is triggered, it scrolls to an element passed by id as parameter. Click on button to scroll to download button (rx.download section) at the bottom of the page
+
 ## rx.redirect
 
 Redirect the user to a new path within the application.
@@ -89,5 +103,5 @@ Parameters:
 ```
 
 ```python demo
-rx.button("Download", on_click=rx.download(url="/reflex_banner.png", filename="different_name_logo.png"))
+rx.button("Download", on_click=rx.download(url="/reflex_banner.png", filename="different_name_logo.png"), id="download button")
 ```

--- a/docs/library/forms/upload.md
+++ b/docs/library/forms/upload.md
@@ -158,7 +158,7 @@ def index():
                     rx.text(img),
                 ),
             ),
-            columns=[2],
+            columns="2",
             spacing="1",
         ),
         padding="5em",


### PR DESCRIPTION
The one step upload example in upload functions throws the below

```
File "/home/eliasderby/Desktop/python/oss/chatapp/chat-venv/lib/python3.11/site-packages/reflex/components/component.py", line 667, in create
    return cls(children=children, **props)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/eliasderby/Desktop/python/oss/chatapp/chat-venv/lib/python3.11/site-packages/reflex/components/component.py", line 330, in __init__
    raise TypeError(
TypeError: Invalid var passed for prop columns, expected type <class 'str'>, got value [2] of type <class 'list'>.
```

