### PR TITLE
Fix titles on API Reference page

### DIFF
--- a/pcweb/pages/docs/apiref.py
+++ b/pcweb/pages/docs/apiref.py
@@ -22,4 +22,6 @@ for module in modules:
     name = module.__name__.lower()
     docs = generate_docs(name, s)
     title = name.replace("_", " ").title()
-    pages.append(docpage(f"/docs/api-reference/{name}", title)(docs))
+    page_data = docpage(f"/docs/api-reference/{name}", title)(docs)
+    page_data.title = page_data.title.split('·')[0].strip()
+    pages.append(page_data)


### PR DESCRIPTION
They used to showing the full titles currently, now it is cleaned up. 

![Screenshot 2024-04-09 at 12 56 38](https://github.com/reflex-dev/reflex-web/assets/159659100/9fb78c86-64d3-40c7-87bc-111cc41f47ff)
