### PR TITLE
docs: Update README to reflect Python 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Reflex is a full-stack web framework that allows developers to build their app i
 
 ## Requirements
 
-The only requirement is that you have installed `Python 3.8` or higher in your local machine.
+The only requirement is that you have installed `Python 3.9` or higher in your local machine.
 
 ## Setup Locally
 


### PR DESCRIPTION
As the author of `flexdown`, you all know best, but for me it required Python 3.9 to run. I had Python 3.8 install and once I installed 3.9 issue it went away.

With python 3.9, when installing deps:
```
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
ERROR: Ignored the following versions that require a different python version: 0.1.0 Requires-Python >=3.9,<4.0; 0.1.0a4 Requires-Python >=3.9,<4.0; 0.1.0a5 Requires-Python >=3.9,<4.0; 0.1.1 Requires-Python >=3.9,<4.0; 0.1.2 Requires-Python >=3.9,<4.0; 0.1.3 Requires-Python >=3.9,<4.0; 0.1.3a1 Requires-Python >=3.9,<4.0; 0.1.4 Requires-Python >=3.9,<4.0; 0.1.5a1 Requires-Python >=3.9,<4.0; 0.1.5a2 Requires-Python >=3.9,<4.0; 0.1.5a3 Requires-Python >=3.9,<4.0; 0.1.5a4 Requires-Python >=3.9,<4.0; 0.1.5a5 Requires-Python >=3.9,<4.0; 0.1.5a6 Requires-Python >=3.9,<4.0; 0.1.5a7 Requires-Python >=3.9,<4.0; 2.1.0 Requires-Python >=3.9; 2.1.0rc0 Requires-Python >=3.9; 2.1.1 Requires-Python >=3.9; 2.1.2 Requires-Python >=3.9; 2.1.3 Requires-Python >=3.9; 2.1.4 Requires-Python >=3.9; 2.2.0 Requires-Python >=3.9; 2.2.0rc0 Requires-Python >=3.9; 2.2.1 Requires-Python >=3.9
ERROR: Could not find a version that satisfies the requirement flexdown==0.1.5a6 (from versions: none)
ERROR: No matching distribution found for flexdown==0.1.5a6
(venv) ➜  reflex-web git:(main)
```