### PR TITLE
docs: Add Discord Bots to resources in Introduction page

### DIFF
--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -224,3 +224,4 @@ By continuing with our documentation, you will learn how to building awesome app
 For a glimpse of the possibilities, check out these resources:
 
 * For a more real-world example, check out the [tutorial]({tutorial.intro.path}).
+* We have bots that can answer questions and generate Reflex code for you, check them out in #ask-ui and #ask-ai in our [Discord]({constants.DISCORD_URL})! 


### PR DESCRIPTION
Considering the traction in the Discord, I figured it'd be good to call out `#ask-ui` and `#ask-ai` under the resources section. 

## Screenshots

Seems to still be fine on mobile and Discord link works.

<img width="771" alt="CleanShot 2024-04-09 at 14 30 57@2x" src="https://github.com/reflex-dev/reflex-web/assets/29822597/17a87d31-5253-4c48-89c2-1e662f8b6de0">
<img width="531" alt="CleanShot 2024-04-09 at 14 31 17@2x" src="https://github.com/reflex-dev/reflex-web/assets/29822597/981139a2-f98f-4787-80ce-a3d39f66ddd2">
<img width="1275" alt="CleanShot 2024-04-09 at 14 31 24@2x" src="https://github.com/reflex-dev/reflex-web/assets/29822597/817cf9bd-17d1-4259-be08-213c2d1ffa56">
