### PR TITLE
docs: CONTRIBUTING.md does not exist in this repo, point to main reflex repo's CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ We welcome contributions of any size! Below are some good ways to get started in
 -   **GitHub Discussions**: A great way to talk about features you want added or things that are confusing/need clarification.
 -   **GitHub Issues**: [Issues](https://github.com/reflex-dev/reflex/issues) are an excellent way to report bugs. Additionally, you can try and solve an existing issue and submit a PR.
 
-We are actively looking for contributors, no matter your skill level or experience. To contribute check out [CONTIBUTING.md](https://github.com/reflex-dev/reflex-web/blob/main/CONTRIBUTING.md)
+We are actively looking for contributors, no matter your skill level or experience. To contribute check out [CONTIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md)
 
 ## License
 


### PR DESCRIPTION
@picklelo — this is nit, but I noticed that CONTRIBUTING.md does not exist in this repo. The real solution is obviously writing a CONTRIBUTING.md for this repo, but as I imagine it will grow quickly out of date because this repo is not as active, you could point to the main contributing guidelines instead? Or just delete the sentence.

Super nit, but figured I'd flag because I did notice it.