### PR TITLE
Whitelist for local development only

### DIFF
--- a/.github/workflows/whitelist.yml
+++ b/.github/workflows/whitelist.yml
@@ -1,0 +1,12 @@
+name: whitelist check
+
+on:
+  pull_request:
+
+jobs:
+  reflex-web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Assert whitelist is empty
+        run:  echo -e "\nassert not WHITELISTED_PAGES, f'WHITELISTED_PAGES includes {WHITELISTED_PAGES}'" | cat "pcweb/whitelist.py" - | python3

--- a/pcweb/whitelist.py
+++ b/pcweb/whitelist.py
@@ -1,6 +1,6 @@
 # A list of whitelist paths that should be built.
 # If the list is empty, all pages will be built.
-WHITELISTED_PAGES = ["/docs/getting-started", "/docs/gallery", "/blog"]
+WHITELISTED_PAGES = []
 
 
 def _check_whitelisted_path(path):


### PR DESCRIPTION
If you actually have changes to the whitelist logic, then you can always add it with `git add -f`, but otherwise, lets avoid accidentally checking in whitelist changes from now on.