### PR TITLE
requirements.txt: remove email-validator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-email-validator==1.3.0
 black==23.10.0
 pandas>=1.5.3
 psycopg2-binary==2.9.9


### PR DESCRIPTION
email-validator < 2 is not compatible with pydantic v2

it also doesn't seem like we're using it in reflex-web anymore, so removing the requirement such that reflex-web can be deployed when pydantic v2 is installed.