### PR TITLE
Add 404 page only once

### DIFF
--- a/pcweb/pages/__init__.py
+++ b/pcweb/pages/__init__.py
@@ -8,7 +8,7 @@ from .index import index
 from .page404 import page404
 
 routes = [
-    *[r for r in locals().values() if isinstance(r, Route)],
+    *[r for r in locals().values() if isinstance(r, Route) and r.add_as_page],
     *blog_routes,
     *doc_routes,
 ]

--- a/pcweb/pages/page404.py
+++ b/pcweb/pages/page404.py
@@ -8,7 +8,7 @@ The page at `{rx.State.router.page.raw_path}` doesn't exist.
 """
 
 
-@webpage(path="/404", title="Page Not Found · Reflex.dev")
+@webpage(path="/404", title="Page Not Found · Reflex.dev", add_as_page=False)
 def page404():
     return rx.center(
         rx.vstack(

--- a/pcweb/pcweb.py
+++ b/pcweb/pcweb.py
@@ -92,3 +92,5 @@ redirects = [
 
 for source, target in redirects:
     app.add_page(lambda: rx.fragment(), route=source, on_load=rx.redirect(target))
+
+app.add_custom_404_page(page404.component)

--- a/pcweb/pcweb.py
+++ b/pcweb/pcweb.py
@@ -92,5 +92,3 @@ redirects = [
 
 for source, target in redirects:
     app.add_page(lambda: rx.fragment(), route=source, on_load=rx.redirect(target))
-
-app.add_custom_404_page(page404.component)

--- a/pcweb/route.py
+++ b/pcweb/route.py
@@ -19,6 +19,11 @@ class Route(Base):
     # The component to render for the route.
     component: Callable[[], rx.Component]
 
+    # whether to add the route to the app's pages. This is typically used
+    # to delay adding the 404 page(which is explicitly added in pcweb.py).
+    # https://github.com/reflex-dev/reflex-web/pull/659#pullrequestreview-2021171902
+    add_as_page: bool = True
+
 
 def get_path(component_fn: Callable):
     """Get the path for a page based on the file location.

--- a/pcweb/templates/webpage.py
+++ b/pcweb/templates/webpage.py
@@ -65,7 +65,7 @@ def spotlight():
     )
 
 
-def webpage(path: str, title: str = DEFAULT_TITLE, props=None) -> Callable:
+def webpage(path: str, title: str = DEFAULT_TITLE, props=None, add_as_page=True) -> Callable:
     """A template that most pages on the reflex.dev site should use.
 
     This template wraps the webpage with the navbar and footer.
@@ -74,6 +74,7 @@ def webpage(path: str, title: str = DEFAULT_TITLE, props=None) -> Callable:
         path: The path of the page.
         title: The title of the page.
         props: Props to apply to the template.
+        add_as_page: whether to add the route to the app pages.
 
     Returns:
         A wrapper function that returns the full webpage.
@@ -133,6 +134,7 @@ def webpage(path: str, title: str = DEFAULT_TITLE, props=None) -> Callable:
             path=path,
             title=title,
             component=wrapper,
+            add_as_page=add_as_page
         )
 
     return webpage


### PR DESCRIPTION
404 page is already added via `@webpage` decorator in `pcweb/pages/page404`, we shouldn't explicitly add it again via `add_custom_404`

This should unblock https://github.com/reflex-dev/reflex/pull/3155