### PR TITLE
[REF-2311] add repository dispatch workflow

### DIFF
--- a/.github/workflows/repository_dispatch.yml
+++ b/.github/workflows/repository_dispatch.yml
@@ -2,9 +2,6 @@ name: reflex-web-repository-dispatch
 on:
   push:
     branches: ['main']
-  # TODO: remove PR below, only for testing
-  pull_request:
-    branches: ['main']
 jobs:
   test:
     name: reflex-web-repository-dispatch

--- a/.github/workflows/repository_dispatch.yml
+++ b/.github/workflows/repository_dispatch.yml
@@ -1,0 +1,16 @@
+name: reflex-web-repository-dispatch
+on:
+  push:
+    branches: ['main']
+  # TODO: remove PR below, only for testing
+  pull_request:
+jobs:
+  test:
+    name: reflex-web-repository-dispatch
+
+    uses: peter-evans/repository-dispatch@v3
+    with:
+      token: ${{ secrets.PAT }}
+      repository: reflex-dev/reflex-hosting
+      event-type: push
+      client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/repository_dispatch.yml
+++ b/.github/workflows/repository_dispatch.yml
@@ -4,13 +4,14 @@ on:
     branches: ['main']
   # TODO: remove PR below, only for testing
   pull_request:
+    branches: ['main']
 jobs:
   test:
     name: reflex-web-repository-dispatch
 
     uses: peter-evans/repository-dispatch@v3
     with:
-      token: ${{ secrets.PAT }}
+      # token: ${{ secrets.PAT }}
       repository: reflex-dev/reflex-hosting
       event-type: push
       client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/repository_dispatch.yml
+++ b/.github/workflows/repository_dispatch.yml
@@ -8,10 +8,12 @@ on:
 jobs:
   test:
     name: reflex-web-repository-dispatch
-
-    uses: peter-evans/repository-dispatch@v3
-    with:
-      # token: ${{ secrets.PAT }}
-      repository: reflex-dev/reflex-hosting
-      event-type: push
-      client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOSTING_REPOSITORY_DISPATCH }}
+          repository: reflex-dev/reflex-hosting
+          event-type: push
+          client-payload: '{"repo": "${{ github.repository }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
## Summary
- When PR is merged, send repository dispatch event to `reflex-hosting` including the repo name and git sha so reflex-web can be deployed.
## Tests
- With `on: pull_request` set, it sent the event https://github.com/reflex-dev/reflex-web/actions/runs/8902314430/job/24447997804
- Event sent triggered action on reflex-hosting repo: https://github.com/reflex-dev/reflex-hosting/actions/runs/8902316431/job/24448002849