### PR TITLE
fixed alertblock not center, swapped install & learn for onboarding s…

### DIFF
--- a/docs/assets/referencing_assets.md
+++ b/docs/assets/referencing_assets.md
@@ -31,8 +31,7 @@ rx.image(src="/Reflex.svg", width="5em")
 ```
 
 ```md alert
-# Always prefix the asset path with a forward slash `/` to reference the asset from the root of the project,
-or it may not display correctly on non-root pages.
+# Always prefix the asset path with a forward slash `/` to reference the asset from the root of the project, or it may not display correctly on non-root pages.
 ```
 
 ## Favicon

--- a/docs/assets/referencing_assets.md
+++ b/docs/assets/referencing_assets.md
@@ -31,7 +31,7 @@ rx.image(src="/Reflex.svg", width="5em")
 ```
 
 ```md alert
-Always prefix the asset path with a forward slash `/` to reference the asset from the root of the project,
+# Always prefix the asset path with a forward slash `/` to reference the asset from the root of the project,
 or it may not display correctly on non-root pages.
 ```
 

--- a/docs/components/conditional_rendering.md
+++ b/docs/components/conditional_rendering.md
@@ -9,7 +9,7 @@ from pcweb.pages.docs import vars, library
 We use the `cond` component to conditionally render components. The `cond` component acts in a similar way to a conditional (ternary) operator in python, acting in a similar fashion to an `if-else` statement.
 
 ```md alert
-Check out the API reference for [cond docs]({library.layout.cond.path}).
+# Check out the API reference for [cond docs]({library.layout.cond.path}).
 ```
 
 ```python eval

--- a/docs/components/props.md
+++ b/docs/components/props.md
@@ -45,7 +45,7 @@ State may be modified in response to things like user input like clicking a butt
 State vars can be bound to component props, so that the UI always reflects the current state of the app.
 
 ```md alert warning
-Optional: Learn all about [State]({state.overview.path}) first.
+# Optional: Learn all about [State]({state.overview.path}) first.
 ```
 
 You can set the value of a prop to a [state var]({vars.base_vars.path}) to make the component update when the var changes.

--- a/docs/database/queries.md
+++ b/docs/database/queries.md
@@ -154,8 +154,8 @@ SQL strings.  If parameter binding is needed, the query may be wrapped in
 [`sqlalchemy.text`](https://docs.sqlalchemy.org/en/14/core/sqlelement.html#sqlalchemy.sql.expression.text),
 which allows colon-prefix names to be used as placeholders.
 
-```md alert
-Never use string formatting to construct SQL queries, as this may lead to SQL injection vulnerabilities in the app.
+```md alert info
+# Never use string formatting to construct SQL queries, as this may lead to SQL injection vulnerabilities in the app.
 ```
 
 ```python

--- a/docs/events/chaining_events.md
+++ b/docs/events/chaining_events.md
@@ -47,8 +47,8 @@ So far, we have only seen events that are triggered by components. However, an e
 
 In Reflex, event handlers run synchronously, so only one event handler can run at a time, and the events in the queue will be blocked until the current event handler finishes.The difference between returning an event and calling an event handler is that returning an event will send the event to the frontend and unblock the queue.
 
-```md alert
-Be sure to use the class name `State` (or any substate) rather than `self` when returning events.
+```md alert info
+# Be sure to use the class name `State` (or any substate) rather than `self` when returning events.
 ```
 
 Try entering an integer in the input below then clicking out.

--- a/docs/getting-started/how-reflex-works.md
+++ b/docs/getting-started/how-reflex-works.md
@@ -194,7 +194,7 @@ On the frontend, we maintain an event queue of all pending events.
 When an event is triggered, it is added to the queue. We have a `processing` flag to make sure only one event is processed at a time. This ensures that the state is always consistent and there aren't any race conditions with two event handlers modifying the state at the same time.
 
 ```md alert info
-There are exceptions to this, such as [background events]({events.background_events.path}) which allow you to run events in the background without blocking the UI.
+# There are exceptions to this, such as [background events]({events.background_events.path}) which allow you to run events in the background without blocking the UI.
 ```
 
 Once the event is ready to be processed, it is sent to the backend through a WebSocket connection.

--- a/docs/hosting/deploy-quick-start.md
+++ b/docs/hosting/deploy-quick-start.md
@@ -52,7 +52,7 @@ The command is by default interactive. It asks you a few questions for informati
 That’s it! You should receive some feedback on the progress of your deployment and in a few minutes your app should be up. 🎉
 
 ```md alert info
-Once your code is uploaded, the hosting service will start the deployment. After a complete upload, exiting from the command **does not** affect the deployment process. The command prints a message when you can safely close it without affecting the deployment.
+# Once your code is uploaded, the hosting service will start the deployment. After a complete upload, exiting from the command **does not** affect the deployment process. The command prints a message when you can safely close it without affecting the deployment.
 ```
 
 ## See it in Action

--- a/docs/library/forms/select.md
+++ b/docs/library/forms/select.md
@@ -115,7 +115,7 @@ rx.select(["Apple", "Orange", "Banana", "Grape", "Pear"], default_value="Orange"
 Can set the `color`, `variant` and `radius` to easily style the `select`.
 
 ```python demo
-rx.select(["Apple", "Orange", "Banana", "Grape", "Pear"], color="pink", variant="soft", radius="full", width="100%")
+rx.select(["Apple", "Orange", "Banana", "Grape", "Pear"], color="pink", variant="soft", radius="full", width="100%", default_value="apple")
 ```
 
 ## High control of select component (value and open changes)

--- a/docs/library/forms/upload.md
+++ b/docs/library/forms/upload.md
@@ -181,10 +181,8 @@ By convention, Reflex provides the function `rx.get_upload_dir()` to get the dir
 
 The backend of your app will mount this uploaded files directory on `/_upload` without restriction. Any files uploaded via this mechanism will automatically be publicly accessible. To get the URL for a file inside the upload dir, use the `rx.get_upload_url(filename)` function in a frontend component.
 
-```md alert
-When using the Reflex hosting service, the uploaded files directory is not persistent and will be cleared on every deployment.
-
-For persistent storage of uploaded files, it is recommended to use an external service, such as S3.
+```md alert info
+# When using the Reflex hosting service, the uploaded files directory is not persistent and will be cleared on every deployment. For persistent storage of uploaded files, it is recommended to use an external service, such as S3.
 ```
 
 ## Cancellation

--- a/docs/state/overview.md
+++ b/docs/state/overview.md
@@ -162,8 +162,8 @@ independently of other users.
 Because Reflex internally creates a new instance of the state for each user, your code should
 never directly initialize a state class.
 
-```md alert
-Try opening an app in multiple tabs to see how the state changes independently.
+```md alert info
+# Try opening an app in multiple tabs to see how the state changes independently.
 ```
 
 All user state is stored on the server, and all event handlers are executed on

--- a/pcweb/components/docpage/sidebar/sidebar_items/learn.py
+++ b/pcweb/components/docpage/sidebar/sidebar_items/learn.py
@@ -11,8 +11,8 @@ def get_sidebar_items_learn():
         create_item(
             "Getting Started",
             children=[
-                getting_started.introduction,
                 getting_started.installation,
+                getting_started.introduction,
                 getting_started.project_structure,
                 getting_started.configuration,
                 getting_started.how_reflex_works,


### PR DESCRIPTION
1. Fixed some alert block not centering, when alert box has only the body no title, the body should be treated as title, so it aligns to the center. https://linear.app/reflex-dev/issue/REF-2725/alerts-not-centering-heading
2. Swapped install & learn for onboarding section. https://linear.app/reflex-dev/issue/REF-2714/switch-introduction-and-installation-order-on-sidebar
3. On docs/library/forms/select.md, set default to one demo for rx.select doc. https://linear.app/reflex-dev/issue/REF-2778/docslibraryformsselect-simple-styling-demo-have-no-default-selection