### PR TITLE
Fix typo in function parameter (Tutorial - Final App)

### DIFF
--- a/docs/tutorial/final-app.md
+++ b/docs/tutorial/final-app.md
@@ -168,7 +168,7 @@ class TutorialState(rx.State):
         client = AsyncOpenAI(api_key=os.environ["OPENAI_API_KEY"])
         session = await client.chat.completions.create(
             model="gpt-3.5-turbo",
-            messages[\{"role": "user", "content": self.question}],
+            messages=[\{"role": "user", "content": self.question}],
             stop=None,
             temperature=0.7,
             stream=True,


### PR DESCRIPTION
"I found a typo while following a tutorial - (I'm a beginner, haha)."

Before
![image](https://github.com/reflex-dev/reflex-web/assets/28076127/15150e32-3274-45f4-a270-43a44d98b9dc)

After
![image](https://github.com/reflex-dev/reflex-web/assets/28076127/9f8f9006-15ed-4ec4-a6a0-566fe42b38c1)
