### PR TITLE
fix(demos.py): fix gallery URL typo

### DIFF
--- a/pcweb/pages/index/demos/demos.py
+++ b/pcweb/pages/index/demos/demos.py
@@ -70,7 +70,7 @@ def more_examples():
                     border="1px solid rgba(186, 199, 247, 0.12);",
                     text_wrap="nowrap",
                 ),
-                href="/gallery",
+                href="/docs/gallery",
             )
 
 def demos():


### PR DESCRIPTION
Fix homepage gallery URL typo.

Change: `/gallery` to `/docs/gallery`