### PR TITLE
Hanson/sidebar navbar updates

### DIFF
--- a/pcweb/components/docpage/navbar/navbar.py
+++ b/pcweb/components/docpage/navbar/navbar.py
@@ -12,9 +12,14 @@ from .search import search_bar
 from .state import NavbarState
 from pcweb.components.docpage.navbar.nav_menu.nav_menu import nav_menu
 
-def resource_header(text):
-    return rx.text(
-        text, color=rx.color("mauve", 12), font_weight="600"
+def resource_header(text, url):
+    return rx.link(
+        rx.text(
+            text,
+            color=rx.color("mauve", 12),
+            font_weight="600",
+        ),
+        href=url,
     )
 
 
@@ -74,6 +79,7 @@ def menu_trigger():
             "Components", 
             color=rx.color("mauve", 11),
             font="Instrument Sans",
+            weight="medium",
             style={"font-size":"16px"},
         ),
         rx.icon(tag="chevron_down", color=rx.color("mauve", 11), size=18),
@@ -89,7 +95,7 @@ def menu_content():
     return rx.flex(
         rx.flex(
             rx.flex(
-                resource_header("Core Components"),
+                resource_header("Core Components", library.path),
                 resources_item("Library", library.path, "library-big"),
                 resources_item("Theming", styling.theming.path,"palette"),
                 direction="column",
@@ -100,7 +106,7 @@ def menu_content():
             ),
             rx.flex(
                 rx.flex(
-                    resource_header("Custom Components"),
+                    resource_header("Custom Components", custom_components.path),
                     rx.badge("New", variant="solid"),
                     align_items="center",
                     spacing="1",
@@ -160,6 +166,9 @@ def link_item(name: str, url: str):
             rx.text(
                 name, 
                 color=rx.color("mauve", 11),
+                font="Instrument Sans",
+                style={"font-size":"16px"},
+                weight="medium",
             ), 
             height="100%",
         ),
@@ -174,6 +183,7 @@ def navigation_section():
             link_item("Hosting", hosting.deploy_quick_start.path),
             components_section(),
             spacing="5",
+            padding_left="1.25em",
         ),
         display=["none", "none", "none", "flex", "flex", "flex"],
     )

--- a/pcweb/components/docpage/sidebar/sidebar.py
+++ b/pcweb/components/docpage/sidebar/sidebar.py
@@ -57,13 +57,13 @@ def sidebar_leaf(
                 rx.flex(
                     rx.text(
                         section_name,
-                        color=rx.color("mauve", 11),
+                        color=rx.color("mauve", 12),
                         _hover={
                             "color": rx.color("accent", 10),
                             "text_decoration": "none",
                         },
-                        font_weight="bold",
-                        margin_left="1.25em",
+                        font_weight="600",
+                        margin_left="0.75em",
                         margin_top="0.5em",
                         margin_bottom="0.2em",
                         width="100%",
@@ -75,12 +75,12 @@ def sidebar_leaf(
                 rx.flex(
                     rx.text(
                         item.names,
-                        color=rx.color("mauve", 11),
+                        color=rx.color("mauve", 12),
                         _hover={
                             "color": rx.color("accent", 10),
                             "text_decoration": "none",
                         },
-                        font_weight="500",
+                        font_weight="600",
                         margin_left="0.75em",
                         margin_top="0.2em",
                         margin_bottom="0.2em",
@@ -100,7 +100,7 @@ def sidebar_leaf(
                         rx.text(
                             item.names,
                             color=rx.color("accent", 11),
-                            font_weight="500",
+                            font_weight="600",
                             margin_left="0.25em",
                         ),
                         style=heading_style2,
@@ -308,13 +308,17 @@ def sidebar_section(name):
     return rx.text(
         name,
         color=rx.color("mauve", 12),
-        font_weight="500",
+        font_weight="600",
         padding_top="1em",
-        padding_left="10px",
+        padding_left="0.75em",
     )
 
 def create_sidebar_section(section_title, items, index, url):
     return rx.flex(
+        rx.cond(
+            section_title == "Onboarding",
+            sidebar_section(section_title),
+        ),
         rx.chakra.accordion(
             *[
                 sidebar_item_comp(

--- a/pcweb/components/docpage/sidebar/sidebar.py
+++ b/pcweb/components/docpage/sidebar/sidebar.py
@@ -32,36 +32,47 @@ def sidebar_link(*children, **props):
     )
 
 
-def create_item(route: Route, children=None):
-    """Create a sidebar item from a route."""
-    if children is None:
-        name = route.title
-        if name.endswith("Overview"):
-            # For "Overview", we want to keep the qualifier prefix ("Components overview")
-            alt_name_for_next_prev = name
-            name = "Overview"
-        else:
-            alt_name_for_next_prev = ""
-        name = name.replace("Api", "API").replace("Cli", "CLI")
-        return SidebarItem(
-            names=name, alt_name_for_next_prev=alt_name_for_next_prev, link=route.path
-        )
-    return SidebarItem(
-        names=route,
-        children=list(map(create_item, children)),
-    )
-
-
 def sidebar_leaf(
     item: SidebarItem,
     url: str,
 ) -> rx.Component:
     """Get the leaf node of the sidebar."""
-    item.link= item.link.replace("_", "-")
+    item.link=item.link.replace("_", "-")
+    outer=False
     
-    if item.names == "Overview":
-        return sidebar_link(
-            rx.flex(
+    if item.names.endswith("Overview"):
+        url_parts = item.link.split("/")
+        if len(url_parts) >= 4:
+            section_name = url_parts[2].replace("-", " ").title()
+            if section_name == "Ui" or section_name == "State":
+                outer=True
+                if section_name == "Ui":
+                    section_name = section_name.upper()
+        else:
+            section_name = item.names
+
+        return rx.cond(
+            outer, 
+            sidebar_link(
+                rx.flex(
+                    rx.text(
+                        section_name,
+                        color=rx.color("mauve", 11),
+                        _hover={
+                            "color": rx.color("accent", 10),
+                            "text_decoration": "none",
+                        },
+                        font_weight="bold",
+                        margin_left="1.25em",
+                        margin_top="0.5em",
+                        margin_bottom="0.2em",
+                        width="100%",
+                    ),
+                ),
+                href=item.link,
+            ),
+            sidebar_link(
+                rx.flex(
                     rx.text(
                         item.names,
                         color=rx.color("mauve", 11),
@@ -77,6 +88,7 @@ def sidebar_leaf(
                     ),
                 ),
                 href=item.link,
+            )
         )
 
     return rx.chakra.accordion_item(
@@ -301,10 +313,10 @@ def sidebar_section(name):
         padding_left="10px",
     )
 
-
+# TODO
 def create_sidebar_section(section_title, items, index, url):
     return rx.flex(
-        sidebar_section(section_title),
+        # sidebar_section(section_title),
         rx.chakra.accordion(
             *[
                 sidebar_item_comp(
@@ -326,7 +338,7 @@ def create_sidebar_section(section_title, items, index, url):
         align_items="left",
     )
 
-  
+
 @rx.memo
 def sidebar_comp(
     url: str,
@@ -352,8 +364,8 @@ def sidebar_comp(
                 0,
                 rx.flex(
                     create_sidebar_section("Onboarding", learn, learn_index, url),
-                    create_sidebar_section("UI", frontend, frontend_index, url),
-                    create_sidebar_section("State", backend, backend_index, url),
+                    create_sidebar_section("UI Overview", frontend, frontend_index, url),
+                    create_sidebar_section("State Overview", backend, backend_index, url),
                     create_sidebar_section("Hosting", hosting, hosting_index, url),
                     direction="column",
                 ),

--- a/pcweb/components/docpage/sidebar/sidebar.py
+++ b/pcweb/components/docpage/sidebar/sidebar.py
@@ -98,7 +98,7 @@ def sidebar_leaf(
                 rx.flex(
                     rx.flex(
                         rx.text(
-                            item.names,
+                            item.names + item.link + url,
                             color=rx.color("accent", 11),
                             font_weight="500",
                             margin_left="0.25em",
@@ -116,7 +116,7 @@ def sidebar_leaf(
             sidebar_link(
                 rx.flex(
                     rx.text(
-                        item.names,
+                        item.names + item.link + url,
                         color=rx.color("mauve", 11),
                         _hover={
                             "color": rx.color("accent", 11),
@@ -313,10 +313,8 @@ def sidebar_section(name):
         padding_left="10px",
     )
 
-# TODO
 def create_sidebar_section(section_title, items, index, url):
     return rx.flex(
-        # sidebar_section(section_title),
         rx.chakra.accordion(
             *[
                 sidebar_item_comp(
@@ -364,8 +362,8 @@ def sidebar_comp(
                 0,
                 rx.flex(
                     create_sidebar_section("Onboarding", learn, learn_index, url),
-                    create_sidebar_section("UI Overview", frontend, frontend_index, url),
-                    create_sidebar_section("State Overview", backend, backend_index, url),
+                    create_sidebar_section("UI", frontend, frontend_index, url),
+                    create_sidebar_section("State", backend, backend_index, url),
                     create_sidebar_section("Hosting", hosting, hosting_index, url),
                     direction="column",
                 ),

--- a/pcweb/components/docpage/sidebar/sidebar.py
+++ b/pcweb/components/docpage/sidebar/sidebar.py
@@ -98,7 +98,7 @@ def sidebar_leaf(
                 rx.flex(
                     rx.flex(
                         rx.text(
-                            item.names + item.link + url,
+                            item.names,
                             color=rx.color("accent", 11),
                             font_weight="500",
                             margin_left="0.25em",
@@ -116,7 +116,7 @@ def sidebar_leaf(
             sidebar_link(
                 rx.flex(
                     rx.text(
-                        item.names + item.link + url,
+                        item.names,
                         color=rx.color("mauve", 11),
                         _hover={
                             "color": rx.color("accent", 11),

--- a/pcweb/components/docpage/sidebar/sidebar_items/item.py
+++ b/pcweb/components/docpage/sidebar/sidebar_items/item.py
@@ -6,10 +6,10 @@ def create_item(route: Route, children=None):
     """Create a sidebar item from a route."""
     if children is None:
         name = route.title
+        url = route.path
         if name.endswith("Overview"):
             # For "Overview", we want to keep the qualifier prefix ("Components overview")
             alt_name_for_next_prev = name
-            name = "Overview"
         else:
             alt_name_for_next_prev = ""
         name = name.replace("Api", "API").replace("Cli", "CLI")


### PR DESCRIPTION
Three changes in this PR:
1. Cleaned up sidebar of docpages (learn section), there used to have `UI` and `State` section name and their overview under them. The section names are unclickable. I combined them to save space. This change only apply to the outer layer. sidebar.py

2. Adjusted the layout and font size of navbar.  
3. Make "Core component" and "Custom component" in the component navbar clickable, it is now more "prominent" imo. 
