### PR TITLE
Replaced accordion with callout when alert blocks has no content

### DIFF
--- a/pcweb/flexdown.py
+++ b/pcweb/flexdown.py
@@ -51,7 +51,6 @@ class AlertBlock(flexdown.blocks.MarkdownBlock):
         color = colors.get(status, "blue")
 
         has_content = bool(content.strip())
-        print(has_content)
 
         return rx.cond(
             has_content,

--- a/pcweb/flexdown.py
+++ b/pcweb/flexdown.py
@@ -50,41 +50,72 @@ class AlertBlock(flexdown.blocks.MarkdownBlock):
 
         color = colors.get(status, "blue")
 
+        has_content = bool(content.strip())
+        print(has_content)
 
-        return rx.chakra.accordion(
-            rx.chakra.accordion_item(
-                rx.chakra.accordion_button(
-                    rx.hstack(
-                        rx.box(
-                            rx.match(
-                                status,
-                                ("info", rx.icon(tag="info", size=18, margin_right=".5em")),
-                                ("success", rx.icon(tag="circle_check", size=18, margin_right=".5em")),
-                                ("warning", rx.icon(tag="triangle_alert", size=18, margin_right=".5em")),
-                                ("error", rx.icon(tag="ban", size=18, margin_right=".5em")),
-                            )
+        return rx.cond(
+            has_content,
+            rx.chakra.accordion(
+                rx.chakra.accordion_item(
+                    rx.chakra.accordion_button(
+                        rx.hstack(
+                            rx.box(
+                                rx.match(
+                                    status,
+                                    ("info", rx.icon(tag="info", size=18, margin_right=".5em")),
+                                    ("success", rx.icon(tag="circle_check", size=18, margin_right=".5em")),
+                                    ("warning", rx.icon(tag="triangle_alert", size=18, margin_right=".5em")),
+                                    ("error", rx.icon(tag="ban", size=18, margin_right=".5em")),
+                                )
+                            ),
+                            rx.markdown(title) if title else self.render_fn(content=content),
+                            rx.spacer(),
+                            rx.chakra.accordion_icon(color=f"{rx.color(color, 11)}"),
+                            align_items="center",
+                            justify_content="left",
+                            text_align="left",
+                            spacing="2",
+                            width="100%",
                         ),
-                        rx.markdown(title) if title else self.render_fn(content=content),
-                        rx.spacer(),
-                        rx.chakra.accordion_icon(color=f"{rx.color(color, 11)}"),
-                        align_items="center",
-                        justify_content="left",
-                        text_align="left",
-                        spacing="2",
-                        width="100%",
+                        color=f"{rx.color(color, 11)}", 
+                        border_radius="8px",
+                        _hover={},
                     ),
-                    color=f"{rx.color(color, 11)}", 
+                    rx.chakra.accordion_panel(markdown(content)) if title else rx.fragment(),
                     border_radius="8px",
-                    _hover={},
+                    background_color=f"{rx.color(color, 3)}",
+                    border="none",
+                    allow_toggle=True,
                 ),
-                rx.chakra.accordion_panel(markdown(content)) if title else rx.fragment(),
-                border_radius="8px",
-                background_color=f"{rx.color(color, 3)}",
-                border="none"
+                is_disabled = True,
+                allow_toggle=True,
+                width="100%",
+                margin_y="1em"
             ),
-            allow_toggle=True,
-            width="100%",
-            margin_y="1em"
+            rx.vstack(
+                rx.hstack(
+                    rx.box(
+                        rx.match(
+                            status,
+                            ("info", rx.icon(tag="info", size=18, margin_right=".5em")),
+                            ("success", rx.icon(tag="circle_check", size=18, margin_right=".5em")),
+                            ("warning", rx.icon(tag="triangle_alert", size=18, margin_right=".5em")),
+                            ("error", rx.icon(tag="ban", size=18, margin_right=".5em")),
+                        )
+                    ),
+                    rx.markdown(
+                        title,
+                        color=f"{rx.color(color, 11)}"
+                    ),
+                    align_items="center",
+                    spacing="1",
+                    padding_left = "1em",
+                    padding_right = "1em",
+                ),
+                background_color=f"{rx.color(color, 3)}",
+                border_radius="8px",
+                margin_y="1em",
+            )
         )
 
 class SectionBlock(flexdown.blocks.Block):

--- a/pcweb/flexdown.py
+++ b/pcweb/flexdown.py
@@ -53,9 +53,8 @@ class AlertBlock(flexdown.blocks.MarkdownBlock):
 
         has_content = bool(content.strip())
 
-        return rx.cond(
-            has_content,
-            rx.chakra.accordion(
+        if has_content:
+            return rx.chakra.accordion(
                 rx.chakra.accordion_item(
                     rx.chakra.accordion_button(
                         rx.hstack(
@@ -91,8 +90,9 @@ class AlertBlock(flexdown.blocks.MarkdownBlock):
                 allow_toggle=True,
                 width="100%",
                 margin_y="1em"
-            ),
-            rx.vstack(
+            )
+        else:
+            return rx.vstack(
                 rx.hstack(
                     rx.box(
                         rx.match(
@@ -116,7 +116,6 @@ class AlertBlock(flexdown.blocks.MarkdownBlock):
                 border_radius="8px",
                 margin_y="1em",
             )
-        )
 
 class SectionBlock(flexdown.blocks.Block):
     """A block that displays a component along with its code."""

--- a/pcweb/flexdown.py
+++ b/pcweb/flexdown.py
@@ -23,6 +23,7 @@ class AlertBlock(flexdown.blocks.MarkdownBlock):
 
     starting_indicator = "```md alert"
     ending_indicator = "```"
+
     include_indicators = True
 
     def render(self, env) -> rx.Component:


### PR DESCRIPTION
Checkout on /docs/getting-started/how-reflex-works/ where has alert box but no content