### PR TITLE
Convert newsletter signup to use rx.el.form

### DIFF
--- a/pcweb/components/webpage/footer.py
+++ b/pcweb/components/webpage/footer.py
@@ -99,13 +99,13 @@ button_style = {
 }
 
 def news_letter_form():
-    return rx.chakra.form(
+    return rx.el.form(
         rx.chakra.input_group(
             rx.chakra.input_right_element(
                 rx.chakra.button(
                     "->",
+                    type_="submit",
                     color="#FFF",
-                    on_click=IndexState.signup,
                     background="rgba(161, 157, 213, 0.03)",
                     border_left="1px solid rgba(186, 199, 247, 0.12)",
                     border_top_left_radius="0px",
@@ -114,28 +114,28 @@ def news_letter_form():
                 )           
             ),
             rx.chakra.input(
+                name="input_email",
                 placeholder="Your email...",
-                on_blur=IndexState.set_email,
                 color="#fff",
                 background="rgba(161, 157, 213, 0.03)",
                 border="1px solid rgba(186, 199, 247, 0.12)",
-                type="email",
                 border_radius="8px",
             ),
             width="100%",
         ),
-        on_submit = IndexState.signup()
+        on_submit=IndexState.signup,
     )
 
 def message_group():
     return rx.vstack(
         rx.text("You have successfully signed up!", color="#6C6C81"),
-        rx.text(
+        rx.link(
             "Sign up for another email",
+            href="#",
             size='2',
             color="#FFFFFF",
-            style={"text-decoration": "underline"},
-            on_click=IndexState.signup_for_another_user(),
+            underline="always",
+            on_click=IndexState.signup_for_another_user().prevent_default,
         )
     )
 

--- a/pcweb/pages/index/components/news_letter.py
+++ b/pcweb/pages/index/components/news_letter.py
@@ -36,23 +36,23 @@ def message_group():
             font_weight="bold",
             line_height="1",            
         ),
-        rx.text(
+        rx.link(
             "Sign up for another email",
-            size='2',
+            href="#",
             color="#FFFFFF",
-            style={"text-decoration": "underline"},
-            on_click=IndexState.signup_for_another_user(),
+            underline="always",
+            on_click=IndexState.signup_for_another_user().prevent_default,
         )
     )
 
 def news_letter_form() -> rx.Component:
-    return rx.chakra.form(            
+    return rx.el.form(
         rx.chakra.input_group(
             rx.chakra.input_right_element(
                 rx.chakra.button(
                     "Subscribe ->",
+                    type_="submit",
                     color="#FFF",
-                    on_click=IndexState.signup,
                     background="linear-gradient(180deg, #6151F3 0%, #5646ED 100%)",
                     box_shadow="0px 2px 9px -4px rgba(64, 51, 192, 0.70), 0px 0px 6px 2px rgba(255, 255, 255, 0.12) inset, 0px 0px 0px 1px rgba(255, 255, 255, 0.09) inset",
                     border_left="2px solid rgba(186, 199, 247, 0.12)",
@@ -66,19 +66,18 @@ def news_letter_form() -> rx.Component:
                 align="left",
             ),
             rx.chakra.input(
+                name="input_email",
                 placeholder="Enter your email address here",
-                on_blur=IndexState.set_email,
                 color="#fff",
                 background="rgba(161, 157, 213, 0.03)",
                 border="2px solid rgba(186, 199, 247, 0.12)",
-                type="email",
                 border_radius="8px",
                 height="48px",
             ),
         ),
         width="100%",
         height="48px",
-        on_submit=IndexState.signup(),
+        on_submit=IndexState.signup,
     )
 
 def news_letter_section() -> rx.Component:

--- a/pcweb/pcweb.py
+++ b/pcweb/pcweb.py
@@ -25,7 +25,6 @@ app = rx.App(
     theme=rx.theme(
         has_background=True, radius="large", accent_color="violet"
     ),
-    overlay_component=None,
     head_components=[
         rx.el.script(
             src="https://tag.clearbitscripts.com/v1/pk_3d711a6e26de5ddb47443d8db170d506/tags.js",

--- a/pcweb/signup.py
+++ b/pcweb/signup.py
@@ -16,9 +16,6 @@ class Waitlist(rx.Model, table=True):
 class IndexState(rx.State):
     """Hold the state for the home page."""
 
-    # The waitlist email.
-    email: str
-
     # Whether the user signed up for the waitlist.
     signed_up: bool = False
 
@@ -40,32 +37,40 @@ class IndexState(rx.State):
                 response = client.post(url, headers=headers, json=contact_data)
                 response.raise_for_status()  # Raise an exception for HTTP errors (4xx and 5xx)
 
-        except httpx.RequestError as e:
+        except httpx.HTTPError as e:
             print(f"An error occurred: {e}")
     
     def signup_for_another_user(self):
-        self.email = ""
         self.signed_up = False
 
-    def signup(self):
+    def signup(self, form_data: dict[str, str]):
         """Sign the user up for the waitlist."""
 
+        email = form_data.get("input_email", None)
+        if not email:
+            return
+
         try:
-            validation = validate_email(self.email, check_deliverability=True)
-            self.email = validation.email
+            validation = validate_email(email, check_deliverability=True)
+            email = validation.email
         except EmailNotValidError as e:
             # Alert the error message.
-            return rx.window_alert(str(e))
+            return rx._x.toast.warning(
+                str(e),
+                style={
+                    "border": "1px solid #3C3646",
+                    "background": "linear-gradient(218deg, #1D1B23 -35.66%, #131217 100.84%)",
+                }
+            )
 
         # Check if the user is already on the waitlist.
         with rx.session() as session:
-            user = session.query(Waitlist).filter(Waitlist.email == self.email).first()
+            user = session.query(Waitlist).filter(Waitlist.email == email).first()
             if user is None:
                 # Add the user to the waitlist.
-                session.add(Waitlist(email=self.email))
+                session.add(Waitlist(email=email))
                 session.commit()
-                contact_data = json.dumps({"email": self.email})
+                contact_data = json.dumps({"email": email})
                 self.add_contact_to_loops(contact_data)
 
-        self.email = ""
         self.signed_up = True


### PR DESCRIPTION
Updating the state var with on_blur didn't work correctly with the on_submit handler, causing users to get an invalid error the first time they submitted the form (it worked the second time).

Replace the window_alert with a toast for email validation errors.

Use `name` instead of `id` since the form field is used in multiple places on the page and the refs were conflicting when multiple elements had the same id.

Replace the link-like post-sign-up text with an actual link for accessibility.

Re-enable the connection toaster.

Catch HTTPError from attempting the Loops request

I think the intent was to catch and log errors from the loops requests (for example, missing API key), but RequestError does not catch issues like bad HTTP status that come from `response.raise_for_status()`