### PR TITLE
Fix feedback buttons for reflex-0.5.0

### DIFF
--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -38,24 +38,26 @@ def feedback_content(icon, score):
                         placeholder="Contact Info (Optional)",
                         _type="email",
                         name="email",
+                        custom_attrs={"auto_focus": True},
                     ),
                     rx.text_area(
                         placeholder="Write a comment…",
-                        style={"height": 80},
                         name="feedback",
+                        auto_height=True,
+                        enter_key_submit=True,
+                        min_height="0px",
+                        rows="1",
                     ),
                     spacing="1",
                     direction="column",
                 ),
-                rx.popover.close(
-                    rx.flex(
-                        rx.button(
-                            "Send Feedback", size="1", width="100%", type="submit"
-                        ),
-                        spacing="3",
-                        margin_top="12px",
-                        justify="between",
-                    )
+                rx.flex(
+                    rx.button(
+                        "Send Feedback", size="1", width="100%", type="submit"
+                    ),
+                    spacing="3",
+                    margin_top="12px",
+                    justify="between",
                 ),
                 on_submit=lambda feedback: FeedbackState.handle_submit(feedback, score),
             ),
@@ -78,6 +80,7 @@ def feedback(text, icon, score):
                 border_radius="5px",
                 padding="0px 10px",
                 spacing="2",
+                cursor="pointer",
             )
         ),
         rx.popover.content(

--- a/pcweb/templates/docpage/state.py
+++ b/pcweb/templates/docpage/state.py
@@ -33,11 +33,12 @@ class FeedbackState(rx.State):
             email = form_data["email"]
 
         if len(feedback) < 10 or len(feedback) > 500:
-            return rx.window_alert(
-                "Please enter your feedback. Between 10 and 500 characters."
+            return rx._x.toast.warning(
+                "Please enter your feedback. Between 10 and 500 characters.",
+                close_button=True,
             )
 
-        current_page_route = self.get_current_page()
+        current_page_route = self.router.page.raw_path
 
         discord_message = f"""
 Contact: {email}
@@ -51,6 +52,15 @@ Feedback: {feedback}
         try:
             requests.post(DISCORD_WEBHOOK_URL, json=payload)
         except:
-            pass
+            return rx._x.toast.error(
+                "An error occurred while submitting your feedback. If the issue persists, "
+                "please file a Github issue or stop by our discord.",
+                close_button=True,
+            )
+        else:
+            yield rx._x.toast.success(
+                "Thank you for your feedback!",
+                close_button=True,
+            )
 
         self.feedback_open[score] = False


### PR DESCRIPTION
The `get_current_page` method was removed in 0.5.0, which broke the feedback submission mechanism. Use the new router.page.raw_path var instead.

Use a cursor pointer for the feedback buttons.

Functional autoFocus for the form field in the feedback popovers.

Replace window alert with toast for
  * message too short
  * feedback couldn't send
  * success

Close the popover using state instead of rx.popover.close so that too short and failed feedbacks are not lost. The popover remains open unless the feedback was successfully send, this allows the user to type more or copy/paste their message to github, etc.

Use auto_height and enter_key_submit for more natural UX.