### PR TITLE
Fix Var _var_is_string deprecation warning

### DIFF
--- a/pcweb/components/docpage/navbar/inkeep.py
+++ b/pcweb/components/docpage/navbar/inkeep.py
@@ -7,7 +7,7 @@ from reflex.vars import ImportVar, Var
 class Search(rx.Component):
     tag = "SearchBar"
 
-    special_props: Set[Var] = {Var.create_safe("{...searchBarProps}")}
+    special_props: Set[Var] = {Var.create_safe("{...searchBarProps}", _var_is_string=False)}
 
     is_open: Var[bool] = False
 

--- a/pcweb/components/webpage/navbar/inkeep.py
+++ b/pcweb/components/webpage/navbar/inkeep.py
@@ -7,7 +7,7 @@ from reflex.vars import ImportVar, Var
 class Search(rx.Component):
     tag = "SearchBar"
 
-    special_props: Set[Var] = {Var.create_safe("{...searchBarProps}")}
+    special_props: Set[Var] = {Var.create_safe("{...searchBarProps}", _var_is_string=False)}
 
     is_open: Var[bool] = False
 

--- a/pcweb/pages/docs/custom_components.py
+++ b/pcweb/pages/docs/custom_components.py
@@ -207,7 +207,8 @@ def component_description(summary: str) -> rx.Component:
 def add_item(category: dict) -> rx.Component:
     # Format the package name to be more human readable
     name = rx.Var.create(
-        f"{{{category['package_name']._var_name}.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')}}"
+        f"{{{category['package_name']._var_name}.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')}}",
+        _var_is_string=False,
     )
     return rx.flex(
         rx.box(


### PR DESCRIPTION
Fix deprecation warnings about initializing a Var without specifying _var_is_string