### PR TITLE
[REF-3109] Fix broken icon link in callout docs

### DIFF
--- a/docs/library/datadisplay/callout-ll.md
+++ b/docs/library/datadisplay/callout-ll.md
@@ -23,7 +23,7 @@ rx.callout.root(
 
 The `callout` component is made up of a `callout.root`, which groups `callout.icon` and `callout.text` parts. This component is based on the `div` element and supports common margin props.
 
-The `callout.icon` provides width and height for the `icon` associated with the `callout`. This component is based on the `div` element. See the [**icon** component for all icons that are available.](/docs/library/radix/datadisplay/icon)
+The `callout.icon` provides width and height for the `icon` associated with the `callout`. This component is based on the `div` element. See the [**icon** component for all icons that are available.](/docs/library/datadisplay/icon)
 
 The `callout.text` renders the callout text. This component is based on the `p` element.
 

--- a/docs/library/datadisplay/callout.md
+++ b/docs/library/datadisplay/callout.md
@@ -29,7 +29,7 @@ A `callout` is a short message to attract user's attention.
 rx.callout("You will need admin privileges to install and access this application.", icon="info")
 ```
 
-The `icon` prop allows an icon to be passed to the `callout` component. See the [**icon** component for all icons that are available.](/docs/library/radix/datadisplay/icon)
+The `icon` prop allows an icon to be passed to the `callout` component. See the [**icon** component for all icons that are available.](/docs/library/datadisplay/icon)
 
 ## As alert
 


### PR DESCRIPTION
Fix https://github.com/reflex-dev/reflex-web/issues/720