### PR TITLE
docs: Add note to select blank template after reflex init in setup tutorial

### DIFF
--- a/docs/tutorial/setup.md
+++ b/docs/tutorial/setup.md
@@ -21,6 +21,9 @@ $ source venv/bin/activate
 
 Now, we will install Reflex and create a new project. This will create a new directory structure in our project directory.
 
+> **Note:** When prompted to select a template, choose option 0 for a blank project.
+
+
 ```bash
 chatapp $ pip install reflex
 chatapp $ reflex init
@@ -33,7 +36,6 @@ assets          chatapp         rxconfig.py     venv
 ```python eval
 rx.box(height="20px")
 ```
-
 You can run the template app to make sure everything is working.
 
 ```bash


### PR DESCRIPTION
Added a note in the setup tutorial to instruct users to select option 0 (blank template) when prompted during the `reflex init` command. This ensures clarity and helps users set up an empty project correctly.