### PR TITLE
Fix:Correct 'Edit this page' link in documentation footer

### DIFF
--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -98,9 +98,8 @@ def docpage_footer(path: str):
     from pcweb.pages.docs import getting_started, hosting
     from pcweb.pages.changelog import changelog
 
-    path = str(path)
-    if len(path) > 0 and path[-1] == '/':
-        path = path[:-1]
+    
+    path = path[:-1]
     return rx.flex(
         rx.divider(size="4"),
         rx.flex(

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -97,7 +97,7 @@ def docpage_footer(path: str):
     from pcweb.pages.docs.gallery import gallery
     from pcweb.pages.docs import getting_started, hosting
     from pcweb.pages.changelog import changelog
-    normalised_path = normalised_path(path)
+    normalised_path = normalize_path(path)
     return rx.flex(
         rx.divider(size="4"),
         rx.flex(
@@ -154,7 +154,7 @@ def docpage_footer(path: str):
                             padding="0px 10px",
                             white_space="nowrap",
                         ),
-                        href=f"https://github.com/reflex-dev/reflex-web/blob/main/docs/getting-started/introduction.md",
+                        href=f"https://github.com/reflex-dev/reflex-web/blob/main{normalised_path}.md",
                     )
                 ),
                 spacing="2",

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -97,6 +97,7 @@ def docpage_footer(path: str):
     from pcweb.pages.docs.gallery import gallery
     from pcweb.pages.docs import getting_started, hosting
     from pcweb.pages.changelog import changelog
+    print(f"Received path: {path}")
     return rx.flex(
         rx.divider(size="4"),
         rx.flex(

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -97,6 +97,7 @@ def docpage_footer(path: str):
     from pcweb.pages.docs.gallery import gallery
     from pcweb.pages.docs import getting_started, hosting
     from pcweb.pages.changelog import changelog
+    normalised_path = normalised_path(path)
     return rx.flex(
         rx.divider(size="4"),
         rx.flex(
@@ -138,7 +139,7 @@ def docpage_footer(path: str):
                             padding="0px 10px",
                             white_space="nowrap",
                         ),
-                        href=f"https://github.com/reflex-dev/reflex-web/issues/new?title=Issue with reflex.dev documentation&amp;body=Path: {path}",
+                        href=f"https://github.com/reflex-dev/reflex-web/issues/new?title=Issue with reflex.dev documentation&amp;body=Path: {normalised_path}",
                     )
                 ),
                 rx.desktop_only(
@@ -153,7 +154,7 @@ def docpage_footer(path: str):
                             padding="0px 10px",
                             white_space="nowrap",
                         ),
-                        href=f"https://github.com/reflex-dev/reflex-web/tree/main{path}.md",
+                        href=f"https://github.com/reflex-dev/reflex-web/blob/main/docs/getting-started/introduction.md",
                     )
                 ),
                 spacing="2",
@@ -231,6 +232,16 @@ def docpage_footer(path: str):
         spacing="2",
         margin_bottom="2em",
     )
+def normalize_path(path: str) -> str:
+    # Ensure there's no trailing slash, and the path is correctly formatted
+    if path.endswith('/'):
+        path = path[:-1]
+    
+    # Combine path with .md only if it doesn't already have one
+    if not path.endswith('.md'):
+        path += '.md'
+    
+    return path
 
 
 def breadcrumb(path):

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -100,12 +100,7 @@ def docpage_footer(path: str):
     # Directly normalize and strip the path in the href assignment
     normalised_path = path.strip("/") # Adjust this as necessary
 
-    # Ensure it ends with .md
-    if not href_path.endswith('.md'):
-        href_path += '.md'
-
-    # Print href_path to the console for debugging
-    print(f"href_path: {href_path}")
+   
 
     return rx.flex(
         rx.divider(size="4"),

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -97,7 +97,8 @@ def docpage_footer(path: str):
     from pcweb.pages.docs.gallery import gallery
     from pcweb.pages.docs import getting_started, hosting
     from pcweb.pages.changelog import changelog
-    print(f"Received path: {path}")
+    if len(path) > 0 and path[-1] == '/':
+        path = path[:-1]
     return rx.flex(
         rx.divider(size="4"),
         rx.flex(
@@ -154,7 +155,7 @@ def docpage_footer(path: str):
                             padding="0px 10px",
                             white_space="nowrap",
                         ),
-                        href=f"https://github.com/reflex-dev/reflex-web/blob/main/docs/getting-started/introduction.md",
+                        href=f"https://github.com/reflex-dev/reflex-web/blob/main{path}.md",
                     )
                 ),
                 spacing="2",

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -99,7 +99,8 @@ def docpage_footer(path: str):
     from pcweb.pages.changelog import changelog
 
     
-    path = path[:-1]
+    
+    path = path.strip('/')
     return rx.flex(
         rx.divider(size="4"),
         rx.flex(

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -233,11 +233,15 @@ def docpage_footer(path: str):
         margin_bottom="2em",
     )
 def normalize_path(path: str) -> str:
-    # Ensure there's no trailing slash, and the path is correctly formatted
+    # Ensure the path is treated as a string
+    if hasattr(path, "get"):
+        path = path.get()
+    
+    # Remove trailing slash if present
     if path.endswith('/'):
         path = path[:-1]
     
-    # Combine path with .md only if it doesn't already have one
+    # Ensure the path ends with .md
     if not path.endswith('.md'):
         path += '.md'
     

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -98,9 +98,10 @@ def docpage_footer(path: str):
     from pcweb.pages.docs import getting_started, hosting
     from pcweb.pages.changelog import changelog
 
-    
-    if path[-1] == '/':
-        path = path.strip('/')
+    is_path_end_slash = rx.cond((path.at(-1)) == "/", True, False)
+
+    if is_path_end_slash:
+        path = rx.call("strip", path)
     return rx.flex(
         rx.divider(size="4"),
         rx.flex(

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -98,7 +98,7 @@ def docpage_footer(path: str):
     from pcweb.pages.docs import getting_started, hosting
     from pcweb.pages.changelog import changelog
 
-    is_path_end_slash = rx.cond((path.at(-1)) == "/", True, False)
+    is_path_end_slash = rx.cond((path[-1]) == "/", True, False)
 
     if is_path_end_slash:
         path = rx.call("strip", path)

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -97,11 +97,6 @@ def docpage_footer(path: str):
     from pcweb.pages.docs.gallery import gallery
     from pcweb.pages.docs import getting_started, hosting
     from pcweb.pages.changelog import changelog
-    # Directly normalize and strip the path in the href assignment
-    normalised_path = path.strip("/") # Adjust this as necessary
-
-   
-
     return rx.flex(
         rx.divider(size="4"),
         rx.flex(
@@ -143,7 +138,7 @@ def docpage_footer(path: str):
                             padding="0px 10px",
                             white_space="nowrap",
                         ),
-                        href=f"https://github.com/reflex-dev/reflex-web/issues/new?title=Issue with reflex.dev documentation&amp;body=Path: {normalised_path}",
+                        href=f"https://github.com/reflex-dev/reflex-web/issues/new?title=Issue with reflex.dev documentation&amp;body=Path: {path}",
                     )
                 ),
                 rx.desktop_only(
@@ -158,7 +153,7 @@ def docpage_footer(path: str):
                             padding="0px 10px",
                             white_space="nowrap",
                         ),
-                        href=f"https://github.com/reflex-dev/reflex-web/blob/main{normalised_path}.md",
+                        href=f"https://github.com/reflex-dev/reflex-web/blob/main/docs/getting-started/introduction.md",
                     )
                 ),
                 spacing="2",

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -99,8 +99,8 @@ def docpage_footer(path: str):
     from pcweb.pages.changelog import changelog
 
     is_path_end_slash = rx.cond((path[-1]) == "/", True, False)
-
-    path = rx.cond(is_path_end_slash,rx.call("strip", path, "/"), path)
+    processed_path = path.rstrip("/") if path.endswith("/") else path
+    path = rx.cond(is_path_end_slash,processed_path,path)
     return rx.flex(
         rx.divider(size="4"),
         rx.flex(

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -98,7 +98,7 @@ def docpage_footer(path: str):
     from pcweb.pages.docs import getting_started, hosting
     from pcweb.pages.changelog import changelog
     # Directly normalize and strip the path in the href assignment
-    normalised_path = path.rstrip('/').replace("{path}", "resolved-path")  # Adjust this as necessary
+    normalised_path = path.strip("/") # Adjust this as necessary
 
     # Ensure it ends with .md
     if not href_path.endswith('.md'):
@@ -241,20 +241,6 @@ def docpage_footer(path: str):
         spacing="2",
         margin_bottom="2em",
     )
-def normalize_path(path: str) -> str:
-    # Ensure the path is treated as a string
-    if hasattr(path, "get"):
-        path = path.get()
-    
-    # Remove trailing slash if present
-    if path.endswith('/'):
-        path = path[:-1]
-    
-    # Ensure the path ends with .md
-    if not path.endswith('.md'):
-        path += '.md'
-    
-    return path
 
 
 def breadcrumb(path):

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -99,8 +99,7 @@ def docpage_footer(path: str):
     from pcweb.pages.changelog import changelog
 
     is_path_end_slash = rx.cond((path[-1]) == "/", True, False)
-    processed_path = path.rstrip("/") if path.endswith("/") else path
-    path = rx.cond(is_path_end_slash,processed_path,path)
+    path = rx.cond(is_path_end_slash, path[:-1], path)
     return rx.flex(
         rx.divider(size="4"),
         rx.flex(

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -97,7 +97,16 @@ def docpage_footer(path: str):
     from pcweb.pages.docs.gallery import gallery
     from pcweb.pages.docs import getting_started, hosting
     from pcweb.pages.changelog import changelog
-    normalised_path = normalize_path(str(path))
+    # Directly normalize and strip the path in the href assignment
+    normalised_path = path.rstrip('/').replace("{path}", "resolved-path")  # Adjust this as necessary
+
+    # Ensure it ends with .md
+    if not href_path.endswith('.md'):
+        href_path += '.md'
+
+    # Print href_path to the console for debugging
+    print(f"href_path: {href_path}")
+
     return rx.flex(
         rx.divider(size="4"),
         rx.flex(

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -99,8 +99,8 @@ def docpage_footer(path: str):
     from pcweb.pages.changelog import changelog
 
     
-    
-    path = path.strip('/')
+    if path[-1] == '/':
+        path = path.strip('/')
     return rx.flex(
         rx.divider(size="4"),
         rx.flex(

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -97,6 +97,8 @@ def docpage_footer(path: str):
     from pcweb.pages.docs.gallery import gallery
     from pcweb.pages.docs import getting_started, hosting
     from pcweb.pages.changelog import changelog
+
+    path = str(path)
     if len(path) > 0 and path[-1] == '/':
         path = path[:-1]
     return rx.flex(

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -100,8 +100,7 @@ def docpage_footer(path: str):
 
     is_path_end_slash = rx.cond((path[-1]) == "/", True, False)
 
-    if is_path_end_slash:
-        path = rx.call("strip", path)
+    path = rx.cond(is_path_end_slash,rx.call("strip", path, "/"), path)
     return rx.flex(
         rx.divider(size="4"),
         rx.flex(

--- a/pcweb/templates/docpage/docpage.py
+++ b/pcweb/templates/docpage/docpage.py
@@ -97,7 +97,7 @@ def docpage_footer(path: str):
     from pcweb.pages.docs.gallery import gallery
     from pcweb.pages.docs import getting_started, hosting
     from pcweb.pages.changelog import changelog
-    normalised_path = normalize_path(path)
+    normalised_path = normalize_path(str(path))
     return rx.flex(
         rx.divider(size="4"),
         rx.flex(


### PR DESCRIPTION
I have added a normalised_path variable to redirect the trailing slashes request as well to the correct path and making it generic