### PR TITLE
changed selection color for index page

### DIFF
--- a/pcweb/pages/index/index.py
+++ b/pcweb/pages/index/index.py
@@ -33,4 +33,10 @@ def index() -> rx.Component:
         ),
         width="100%",
         direction="column",
+        style={
+            "::selection":{
+                "color":"inherit",
+                "background":"inherit"
+            }
+        }
     )


### PR DESCRIPTION
I have changed the selection colour for the reflex main page. It looked like this before
![image](https://github.com/user-attachments/assets/111ff8a5-bae2-450f-963c-bfa333182f73)
