### PR TITLE
Add Skeleton component documentation

### DIFF
--- a/docs/library/other/skeleton.md
+++ b/docs/library/other/skeleton.md
@@ -22,6 +22,6 @@ rx.vstack(
 ),
 ```
 
-When using `Skeleton` with text, wrap the text itself instead of the element instead of the parent element to have a placeholder of the same size.
+When using `Skeleton` with text, wrap the text itself instead of the parent element to have a placeholder of the same size.
 
 Use the loading prop to control whether the skeleton or its children are displayed. Skeleton preserves the dimensions of children when they are hidden and disables interactive elements.

--- a/docs/library/other/skeleton.md
+++ b/docs/library/other/skeleton.md
@@ -1,0 +1,27 @@
+---
+description: Skeleton, a loading placeholder component for content that is not yet available.
+components:
+    - rx.skeleton
+---
+
+```python exec
+import reflex as rx
+```
+
+# Skeleton (loading placeholder)
+
+`Skeleton` is a loading placeholder component that serves as a visual placeholder while content is loading.
+It is useful for maintaining the layout's structure and providing users with a sense of progression while awaiting the final content.
+
+```python demo
+rx.vstack(
+    rx.skeleton(rx.button("button-small"), height="10px"),
+    rx.skeleton(rx.button("button-big"), height="20px"),
+    rx.skeleton(rx.text("Text is loaded."), loading=True,),
+    rx.skeleton(rx.text("Text is already loaded."), loading=False,),
+),
+```
+
+When using `Skeleton` with text, wrap the text itself instead of the element instead of the parent element to have a placeholder of the same size.
+
+Use the loading prop to control whether the skeleton or its children are displayed. Skeleton preserves the dimensions of children when they are hidden and disables interactive elements.


### PR DESCRIPTION
This pull request adds documentation for the Skeleton component in the library. The new file, `skeleton.md`, provides an overview of the Skeleton component, which serves as a loading placeholder for content that is not yet available.

The documentation includes:

1. A brief description of the Skeleton component and its purpose.
2. A demo showcasing different uses of the Skeleton component, including:
   - Skeleton placeholders for buttons of different sizes
   - Skeleton placeholders for text elements with loading states
3. Usage tips for implementing Skeleton with text elements.
4. Information on using the `loading` prop to control the visibility of the skeleton or its children.

This addition will help users understand and implement the Skeleton component in their Reflex applications, improving the user experience during content loading.
