### PR TITLE
Add DataList component to the documentation

### DIFF
--- a/docs/library/datadisplay/data_list.md
+++ b/docs/library/datadisplay/data_list.md
@@ -1,0 +1,25 @@
+---
+components:
+    - rx.datalist
+---
+
+```python exec
+import reflex as rx
+```
+
+# Data List
+
+The `DataList` component displays key-value pairs and is particularly helpful for showing metadata.
+
+A `DataList` needs to be initialized using `rx.data_list.root()` and currently takes in data list items: `rx.data_list.item`
+
+```python demo
+rx.data_list.root(
+    rx.data_list.item(
+        rx.data_list.label("test"), rx.data_list.value("test"),
+    ),
+    rx.data_list.item(
+        rx.data_list.label("test"), rx.data_list.value("test"),
+    ),
+)
+```

--- a/docs/library/datadisplay/data_list.md
+++ b/docs/library/datadisplay/data_list.md
@@ -1,6 +1,6 @@
 ---
 components:
-    - rx.datalist
+    - rx.data_list
 ---
 
 ```python exec


### PR DESCRIPTION
This pull request adds documentation for the `DataList` component in the Reflex library. The new markdown file introduces the `DataList` component, explaining its purpose for displaying key-value pairs and metadata. It provides a basic example of how to initialize and use the `DataList` component with `rx.data_list.root()` and `rx.data_list.item`. The documentation also mentions potential future improvements to simplify the initialization process for `DataList`.
