### PR TITLE
Reference the data_list.root component

### DIFF
--- a/docs/library/datadisplay/data_list.md
+++ b/docs/library/datadisplay/data_list.md
@@ -1,6 +1,6 @@
 ---
 components:
-    - rx.data_list
+    - rx.data_list.root
 ---
 
 ```python exec


### PR DESCRIPTION
Unbreak the build.

The other components cannot be included because they are missing descriptive comments in reflex.