### PR TITLE
Refactor data component creation logic in generate_props function

### DIFF
--- a/docs/library/datadisplay/data_list.md
+++ b/docs/library/datadisplay/data_list.md
@@ -14,12 +14,46 @@ The `DataList` component displays key-value pairs and is particularly helpful fo
 A `DataList` needs to be initialized using `rx.data_list.root()` and currently takes in data list items: `rx.data_list.item`
 
 ```python demo
-rx.data_list.root(
-    rx.data_list.item(
-        rx.data_list.label("test"), rx.data_list.value("test"),
-    ),
-    rx.data_list.item(
-        rx.data_list.label("test"), rx.data_list.value("test"),
-    ),
-)
+rx.card(
+                rx.data_list.root(
+                    rx.data_list.item(
+                        rx.data_list.label("Status"),
+                        rx.data_list.value(
+                            rx.badge(
+                                "Authorized",
+                                variant="soft",
+                                radius="full",
+                            )
+                        ),
+                        align="center",
+                    ),
+                    rx.data_list.item(
+                        rx.data_list.label("ID"),
+                        rx.data_list.value(rx.code("U-474747")),
+                    ),
+                    rx.data_list.item(
+                        rx.data_list.label("Name"),
+                        rx.data_list.value("Developer Success"),
+                        align="center",
+                    ),
+                    rx.data_list.item(
+                        rx.data_list.label("Email"),
+                        rx.data_list.value(
+                            rx.link(
+                                "success@reflex.dev",
+                                href="mailto:success@reflex.dev",
+                            ),
+                        ),
+                    ),
+                    rx.data_list.item(
+                        rx.data_list.label("Company"),
+                        rx.data_list.value(
+                            rx.link(
+                                "Reflex",
+                                href="https://reflex.dev",
+                            ),
+                        ),
+                    ),
+                ),
+            ),
 ```

--- a/pcweb/pages/docs/component.py
+++ b/pcweb/pages/docs/component.py
@@ -870,6 +870,20 @@ def generate_props(src, component, comp):
         background=c_color("slate", 2),
     )
 
+    def is_ineligble_data_component(
+        component,
+    ) -> bool:
+        component_name: str = component.__name__.lower()
+        match component_name:
+            case "datalistroot":
+                return False
+
+            case component_name if "data" in component_name:
+                return True
+
+            case _:
+                return False
+
     try:
         if f"{component.__name__}" in comp.metadata:
             comp = eval(comp.metadata[component.__name__])(**prop_dict)
@@ -880,10 +894,13 @@ def generate_props(src, component, comp):
         else:
             try:
                 comp = rx.vstack(component.create("Test", **prop_dict))
+
             except:
                 comp = rx.fragment()
-            if "data" in component.__name__.lower():
+
+            if is_ineligble_data_component(component):
                 raise Exception("Data components cannot be created")
+
     except Exception as e:
         print(f"Failed to create component {component.__name__}, error: {e}")
         comp = rx.fragment()


### PR DESCRIPTION
This pull request introduces a new function `is_ineligble_data_component` to improve the handling of data components in the `generate_props` function. The new function determines whether a component should be considered ineligible for creation based on its name.

The main changes include:

1. Adding the `is_ineligble_data_component` function to check component eligibility.
2. Updating the component creation logic to use the new function.
3. Improving the exception handling for data components.

These changes enhance the component generation process and provide more accurate handling of data-related components.
