### PR TITLE
Expand DataList component in examples

### DIFF
--- a/docs/library/datadisplay/data_list.md
+++ b/docs/library/datadisplay/data_list.md
@@ -14,12 +14,46 @@ The `DataList` component displays key-value pairs and is particularly helpful fo
 A `DataList` needs to be initialized using `rx.data_list.root()` and currently takes in data list items: `rx.data_list.item`
 
 ```python demo
-rx.data_list.root(
-    rx.data_list.item(
-        rx.data_list.label("test"), rx.data_list.value("test"),
-    ),
-    rx.data_list.item(
-        rx.data_list.label("test"), rx.data_list.value("test"),
-    ),
-)
+rx.card(
+                rx.data_list.root(
+                    rx.data_list.item(
+                        rx.data_list.label("Status"),
+                        rx.data_list.value(
+                            rx.badge(
+                                "Authorized",
+                                variant="soft",
+                                radius="full",
+                            )
+                        ),
+                        align="center",
+                    ),
+                    rx.data_list.item(
+                        rx.data_list.label("ID"),
+                        rx.data_list.value(rx.code("U-474747")),
+                    ),
+                    rx.data_list.item(
+                        rx.data_list.label("Name"),
+                        rx.data_list.value("Developer Success"),
+                        align="center",
+                    ),
+                    rx.data_list.item(
+                        rx.data_list.label("Email"),
+                        rx.data_list.value(
+                            rx.link(
+                                "success@reflex.dev",
+                                href="mailto:success@reflex.dev",
+                            ),
+                        ),
+                    ),
+                    rx.data_list.item(
+                        rx.data_list.label("Company"),
+                        rx.data_list.value(
+                            rx.link(
+                                "Reflex",
+                                href="https://reflex.dev",
+                            ),
+                        ),
+                    ),
+                ),
+            ),
 ```


### PR DESCRIPTION
This pull request updates the `DataList` component example in the documentation. The new example provides a more comprehensive and visually appealing demonstration of the `DataList` functionality. 

Key changes include:
- Wrapping the `DataList` in a `Card` component for better presentation
- Adding five distinct `DataList` items showcasing various use cases:
  1. A status item with a badge
  2. An ID item using a code block
  3. A name item with centered alignment
  4. An email item with a clickable link
  5. A company item with a clickable link

These changes offer a more realistic and diverse representation of how the `DataList` component can be used in practice, improving the documentation's clarity and usefulness for developers.
