### PR TITLE
Refactor pixels and website trackers into separate file and function

### DIFF
--- a/pcweb/pcweb.py
+++ b/pcweb/pcweb.py
@@ -8,6 +8,7 @@ from pcweb import styles
 from pcweb.pages import page404, routes
 from pcweb.pages.docs import outblocks, exec_blocks
 from pcweb.whitelist import _check_whitelisted_path
+from pcweb.scripts import get_pixel_website_trackers
 
 # This number discovered by trial and error on Windows 11 w/ Node 18, any
 # higher and the prod build fails with EMFILE error.
@@ -27,26 +28,7 @@ app = rx.App(
         radius="large",
         accent_color="violet",
     ),
-    head_components=[
-        rx.el.script(
-            src="https://tag.clearbitscripts.com/v1/pk_3d711a6e26de5ddb47443d8db170d506/tags.js",
-            referrer_policy="strict-origin-when-cross-origin",
-        ),
-        rx.script(src="https://www.googletagmanager.com/gtag/js?id=G-4T7C8ZD9TR"),
-        rx.script(
-            """
-window.dataLayer = window.dataLayer || [];
-function gtag(){window.dataLayer.push(arguments);}
-gtag('js', new Date());
-gtag('config', 'G-4T7C8ZD9TR');
-"""
-        ),
-        rx.script(
-            """!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId setPersonProperties".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('phc_JoMo0fOyi0GQAooY3UyO9k0hebGkMyFJrrCw1Gt5SGb',{api_host:'https://us.i.posthog.com', person_profiles: 'identified_only'
-        })"""
-        ),
-    ],
+    head_components=get_pixel_website_trackers(),
 )
 
 

--- a/pcweb/scripts.py
+++ b/pcweb/scripts.py
@@ -1,0 +1,60 @@
+import reflex as rx
+
+
+PIXEL_GOOGLE_TAG_MANAGER_RUNNER_SCRIPT: str = """
+window.dataLayer = window.dataLayer || [];
+function gtag() {
+    window.dataLayer.push(arguments);
+}
+gtag('js', new Date());
+gtag('config', 'G-4T7C8ZD9TR');
+"""
+PIXEL_POSTHOG_SCRIPT: str = """
+! function(t, e) {
+    var o, n, p, r;
+    e.__SV || (window.posthog = e, e._i = [], e.init = function(i, s, a) {
+        function g(t, e) {
+            var o = e.split(".");
+            2 == o.length && (t = t[o[0]], e = o[1]), t[e] = function() {
+                t.push([e].concat(Array.prototype.slice.call(arguments, 0)))
+            }
+        }(p = t.createElement("script")).type = "text/javascript", p.async = !0, p.src = s.api_host.replace(".i.posthog.com", "-assets.i.posthog.com") + "/static/array.js", (r = t.getElementsByTagName("script")[0]).parentNode.insertBefore(p, r);
+        var u = e;
+        for (void 0 !== a ? u = e[a] = [] : a = "posthog", u.people = u.people || [], u.toString = function(t) {
+                var e = "posthog";
+                return "posthog" !== a && (e += "." + a), t || (e += " (stub)"), e
+            }, u.people.toString = function() {
+                return u.toString(1) + ".people (stub)"
+            }, o = "capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId setPersonProperties".split(" "), n = 0; n < o.length; n++) g(u, o[n]);
+        e._i.push([i, s, a])
+    }, e.__SV = 1)
+}(document, window.posthog || []);
+posthog.init('phc_JoMo0fOyi0GQAooY3UyO9k0hebGkMyFJrrCw1Gt5SGb', {
+    api_host: 'https://us.i.posthog.com',
+    person_profiles: 'identified_only'
+})
+"""
+PIXEL_CLEARBIT_SCRIPT_URL: str = (
+    "https://tag.clearbitscripts.com/v1/pk_3d711a6e26de5ddb47443d8db170d506/tags.js"
+)
+PIXEL_GOOGLE_TAG_MANAGER_SCRIPT_URL: str = (
+    "https://www.googletagmanager.com/gtag/js?id=G-4T7C8ZD9TR"
+)
+
+
+def get_pixel_website_trackers() -> list[rx.Component]:
+    return [
+        rx.el.script(
+            src=PIXEL_CLEARBIT_SCRIPT_URL,
+            referrer_policy="strict-origin-when-cross-origin",
+        ),
+        rx.script(
+            src=PIXEL_GOOGLE_TAG_MANAGER_SCRIPT_URL,
+        ),
+        rx.script(
+            PIXEL_GOOGLE_TAG_MANAGER_RUNNER_SCRIPT,
+        ),
+        rx.script(
+            PIXEL_POSTHOG_SCRIPT,
+        ),
+    ]


### PR DESCRIPTION
This pull request refactors the website tracking scripts implementation. It introduces a new file `scripts.py` that contains constants for various tracking scripts and URLs, as well as a function `get_pixel_website_trackers()` to generate the necessary head components.

The main changes include:

1. Moving the tracking script content and URLs to separate constants in `scripts.py`.
2. Creating a `get_pixel_website_trackers()` function that returns a list of script components.
3. Updating `pcweb.py` to use the new `get_pixel_website_trackers()` function for the `head_components` in the `rx.App` configuration.

This refactoring improves code organization and makes it easier to manage and update tracking scripts in the future.
