### PR TITLE
Add Common Room script to website trackers

### DIFF
--- a/pcweb/scripts.py
+++ b/pcweb/scripts.py
@@ -1,6 +1,27 @@
 import reflex as rx
 
-
+PIXEL_COMMON_ROOM_SCRIPT: str = """
+<script>
+  (function() {
+    if (typeof window === 'undefined') return;
+    if (typeof window.signals !== 'undefined') return;
+    var script = document.createElement('script');
+    script.src = 'https://cdn.cr-relay.com/v1/site/b3e8ad62-9c28-4ad4-b014-925c55d56334/signals.js';
+    script.async = true;
+    window.signals = Object.assign(
+      [],
+      ['page', 'identify', 'form'].reduce(function (acc, method){
+        acc[method] = function () {
+          signals.push([method, arguments]);
+          return signals;
+        };
+       return acc;
+      }, {})
+    );
+    document.head.appendChild(script);
+  })();
+</script>
+"""
 PIXEL_GOOGLE_TAG_MANAGER_RUNNER_SCRIPT: str = """
 window.dataLayer = window.dataLayer || [];
 function gtag() {
@@ -56,5 +77,8 @@ def get_pixel_website_trackers() -> list[rx.Component]:
         ),
         rx.script(
             PIXEL_POSTHOG_SCRIPT,
+        ),
+        rx.el.script(
+            PIXEL_COMMON_ROOM_SCRIPT,
         ),
     ]


### PR DESCRIPTION
This pull request adds Common Room tracking to the website. It introduces a new JavaScript function, `PIXEL_COMMON_ROOM_SCRIPT`, which loads the Common Room signals script and sets up the necessary tracking methods. The script is then included in the `get_pixel_website_trackers()` function, alongside existing tracking scripts for Google Tag Manager and PostHog.
