### PR TITLE
Add Scarf analytics pixel to website trackers

### DIFF
--- a/pcweb/components/docpage/navbar/navbar.py
+++ b/pcweb/components/docpage/navbar/navbar.py
@@ -35,6 +35,7 @@ from pcweb.styles.colors import c_color
 from pcweb.components.docpage.navbar.navmenu.navmenu import nav_menu as new_nav_menu
 from pcweb.styles.shadows import shadows
 from pcweb.constants import CONTRIBUTING_URL, GITHUB_DISCUSSIONS_URL, ROADMAP_URL
+from pcweb.scripts import get_pixel_scarf_image
 
 
 def resource_header(text, url):
@@ -511,7 +512,7 @@ def new_menu_trigger(title: str, url: str = None, active_str: str = "") -> rx.Co
 
 
 def logo() -> rx.Component:
-    return rx.link(
+    reflex_logo: rx.Component = rx.link(
         rx.color_mode_cond(
             rx.image(
                 src="/logos/light/reflex.svg",
@@ -529,6 +530,10 @@ def logo() -> rx.Component:
         flex_shrink="0",
         display="flex",
         href="/",
+    )
+    return rx.hstack(
+        reflex_logo,
+        get_pixel_scarf_image(),
     )
 
 

--- a/pcweb/components/webpage/navbar/navbar.py
+++ b/pcweb/components/webpage/navbar/navbar.py
@@ -15,6 +15,8 @@ from pcweb.pages.blog import blogs
 from pcweb.pages.changelog import changelog
 from pcweb.pages.docs.gallery import gallery
 from pcweb.components.docpage.navbar.nav_menu.nav_menu import nav_menu
+from pcweb.scripts import get_pixel_scarf_image
+
 
 def resource_header(text):
     return rx.text(
@@ -292,11 +294,14 @@ def navbar(sidebar: rx.Component = None) -> rx.Component:
     return rx.flex(
         rx.link(
             rx.box(
-                rx.image(
-                    src="/logos/dark/reflex.svg",
-                    alt="Reflex Logo",
-                    height="20px",
-                    justify="start",
+                rx.hstack(
+                    rx.image(
+                        src="/logos/dark/reflex.svg",
+                        alt="Reflex Logo",
+                        height="20px",
+                        justify="start",
+                    ),
+                    get_pixel_scarf_image(),
                 ),
             ),
             href="/",

--- a/pcweb/scripts.py
+++ b/pcweb/scripts.py
@@ -64,6 +64,16 @@ PIXEL_CLEARBIT_SCRIPT_URL: str = (
 PIXEL_GOOGLE_TAG_MANAGER_SCRIPT_URL: str = (
     "https://www.googletagmanager.com/gtag/js?id=G-4T7C8ZD9TR"
 )
+PIXEL_SCARF_IMAGE_URL: str = (
+    "https://static.scarf.sh/a.png?x-pxid=764c09bd-f62a-4799-a735-fe715e450b3f"
+)
+
+def get_pixel_scarf_image() -> rx.Component:
+    return rx.image(
+        PIXEL_SCARF_IMAGE_URL,
+        referrerpolicy="no-referrer-when-downgrade",
+        hidden=True,
+    )
 
 
 def get_pixel_website_trackers() -> list[rx.Component]:


### PR DESCRIPTION
This pull request adds Scarf analytics to the Pixel website. A new constant `PIXEL_SCARF_IMAGE_URL` is defined, and an image component with this URL is added to the `get_pixel_website_trackers` function. The image is configured with a `referrerpolicy` of "no-referrer-when-downgrade" to enhance privacy and security.
