### PR TITLE
Add Trunk configuration and gitignore

### DIFF
--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,0 +1,9 @@
+*out
+*logs
+*actions
+*notifications
+*tools
+plugins
+user_trunk.yaml
+user.yaml
+tmp

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,0 +1,92 @@
+# This file controls the behavior of Trunk: https://docs.trunk.io/cli
+# To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
+version: 0.1
+
+cli:
+  version: 1.22.4
+
+# Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
+plugins:
+  sources:
+    - id: trunk
+      ref: v1.6.2
+      uri: https://github.com/trunk-io/plugins
+    - id: oss-linter-trunk
+      ref: v0.2024.08.30.18.05
+      uri: https://github.com/reflex-dev/oss-linter-trunk
+
+# Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
+runtimes:
+  enabled:
+    - python@3.10.8
+
+# This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
+lint:
+  enabled:
+    - actionlint@1.7.1
+    - bandit@1.7.9
+    - black@24.8.0
+    - checkov@3.2.239
+    - git-diff-check
+    - isort@5.13.2
+    - markdownlint@0.41.0
+    - osv-scanner@1.8.4
+    - oxipng@9.1.2
+    - pyright@1.1.376
+    - ruff@0.6.2
+    - shellcheck@0.10.0
+    - shfmt@3.6.0
+    - svgo@3.3.2
+    - taplo@0.9.3
+    - trivy@0.54.1
+    - trufflehog@3.81.9
+    - yamllint@1.35.1
+
+  disabled:
+    - flake8
+    - markdown-link-check
+    - mypy
+    - prettier
+    - pylint
+    - remark-lint
+    - stylelint
+    - trunk-toolbox
+
+  exported_configs:
+    - plugin_id: oss-linter-trunk
+      configs:
+        - configs/.bandit
+        - configs/.clang-format
+        - configs/.clang-tidy
+        - configs/.clangd
+        - configs/.editorconfig
+        - configs/.flake8
+        - configs/.gitattributes
+        - configs/.gitignore
+        - configs/.hadolint.yaml
+        - configs/.isort.cfg
+        - configs/.markdownlint.yaml
+        - configs/.mypy.ini
+        - configs/.pr-labels.yaml
+        - configs/.prettierrc.yaml
+        - configs/.pylintrc
+        - configs/.remarkrc.yaml
+        - configs/.shellcheckrc
+        - configs/.sqlfluff
+        - configs/.stylelintrc.js
+        - configs/.stylelintrc.yaml
+        - configs/.yamllint.yaml
+        - configs/pyrightconfig.json
+        - configs/ruff.toml
+        - configs/rustfmt.toml
+        - configs/svgo.config.js
+
+actions:
+  enabled:
+    - trunk-announce
+    - trunk-cache-prune
+    - trunk-upgrade-available
+
+  disabled:
+    - trunk-check-pre-push
+    - trunk-fmt-pre-commit

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -25,7 +25,6 @@ lint:
   enabled:
     - actionlint@1.7.1
     - bandit@1.7.9
-    - black@24.8.0
     - checkov@3.2.239
     - git-diff-check
     - markdownlint@0.41.0
@@ -42,6 +41,7 @@ lint:
     - yamllint@1.35.1
 
   disabled:
+    - black
     - flake8
     - isort
     - markdown-link-check

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -28,7 +28,6 @@ lint:
     - black@24.8.0
     - checkov@3.2.239
     - git-diff-check
-    - isort@5.13.2
     - markdownlint@0.41.0
     - osv-scanner@1.8.4
     - oxipng@9.1.2
@@ -44,6 +43,7 @@ lint:
 
   disabled:
     - flake8
+    - isort
     - markdown-link-check
     - mypy
     - prettier


### PR DESCRIPTION
This pull request introduces Trunk configuration to the project. It adds a `.gitignore` file specific to Trunk, ignoring various output, log, and temporary files. Additionally, it includes a `trunk.yaml` configuration file that sets up linting and formatting tools for the project.

The `trunk.yaml` file configures:
- CLI version
- Plugin sources, including Trunk's official plugins and custom OSS linter plugins
- Python runtime
- A comprehensive set of linters and tools, such as actionlint, bandit, black, checkov, isort, markdownlint, pyright, ruff, and many others
- Disabled linters, including flake8, prettier, and pylint
- Exported configurations for various tools
- Enabled actions like trunk-announce and trunk-cache-prune

This configuration aims to improve code quality and consistency across the project by enforcing a standardized set of linting and formatting rules.
