### PR TITLE
Catch windows signal handling

### DIFF
--- a/pcweb/pcweb.py
+++ b/pcweb/pcweb.py
@@ -107,4 +107,7 @@ def setup_signal_handler():
     signal.signal(signal.SIGUSR1, dump_stacks)
 
 
-setup_signal_handler()
+try:
+    setup_signal_handler()
+except AttributeError:
+    print("Signal handling not supported on this platform")


### PR DESCRIPTION
Windows doesn't have the SIGUSR1 signal, so adding an except for that.