### PR TITLE
Fix table formatting in dynamic routing documentation

### DIFF
--- a/docs/pages/dynamic_routing.md
+++ b/docs/pages/dynamic_routing.md
@@ -115,7 +115,7 @@ Each optional catch-all pattern should be independent and not nested within anot
 | Route Pattern                                         | Example URl                                            |    valid |
 |:------------------------------------------------------|:-------------------------------------------------------|---------:|
 | `/users/posts`                                        | `/users/posts`                                         |    valid |
-| `/products/[category]`                                | `/products/electronics`                                |    valid |                                                  |         |
+| `/products/[category]`                                | `/products/electronics`                                |    valid |
 | `/users/[username]/posts/[id]`                       | `/users/john/posts/5`                                  |    valid |
 | `/users/[...username]/posts`                          | `/users/john/posts`                                    |  invalid |
 |                                                       | `/users/john/doe/posts`                                |  invalid |


### PR DESCRIPTION
This pull request corrects a formatting issue in the dynamic routing documentation. Specifically, it removes an empty cell from the table that displays route pattern examples. This change improves the readability and consistency of the documentation, ensuring that the table is properly formatted and aligned.
