### PR TITLE
Refactor: Move get_component_link import

### DIFF
--- a/pcweb/components/docpage/sidebar/sidebar_items/__init__.py
+++ b/pcweb/components/docpage/sidebar/sidebar_items/__init__.py
@@ -1,0 +1,1 @@
+from .component_lib import get_component_link

--- a/pcweb/pages/docs/library.py
+++ b/pcweb/pages/docs/library.py
@@ -3,7 +3,7 @@ from pcweb.templates.docpage import docpage, h1_comp, text_comp
 
 
 def component_grid():
-    from pcweb.components.docpage.sidebar import get_component_link
+    from pcweb.components.docpage.sidebar.sidebar_items import get_component_link
     from pcweb.pages.docs import component_list, graphing_components
 
     def generate_gallery(


### PR DESCRIPTION
This pull request introduces a new file `__init__.py` in the `pcweb/components/docpage/sidebar/sidebar_items/` directory, which imports the `get_component_link` function from the `component_lib` module. Additionally, it updates the import statement in `pcweb/pages/docs/library.py` to reflect the new location of the `get_component_link` function. This change improves the organization of the codebase by moving the `get_component_link` function to a more appropriate location within the project structure.
