### PR TITLE
Add future annotations import to alembic env.py

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config


### PR DESCRIPTION
Added future import for annotations in alembic/env.py

This change introduces the `from __future__ import annotations` statement at the beginning of the alembic/env.py file. This import enables the use of forward references in type annotations, allowing for more flexible type hinting in the codebase.
