### PR TITLE
Add future annotations import to datatable tutorial utils

### DIFF
--- a/docs/datatable_tutorial/datatable_tutorial_utils.py
+++ b/docs/datatable_tutorial/datatable_tutorial_utils.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import asyncio
 from typing import Any
 


### PR DESCRIPTION
Added future import for annotations to improve type hinting compatibility across Python versions in the datatable tutorial utilities file.
