### PR TITLE
Add future annotations and type hints to tutorial utils

### DIFF
--- a/docs/tutorial/tutorial_utils.py
+++ b/docs/tutorial/tutorial_utils.py
@@ -1,6 +1,8 @@
-import os
-import openai
+from __future__ import annotations
 
+import os
+
+import openai
 import reflex as rx
 
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
@@ -13,12 +15,12 @@ class ChatappState(rx.State):
     # Keep track of the chat history as a list of (question, answer) tuples.
     chat_history: list[tuple[str, str]]
 
-    def answer(self):
+    def answer(self) -> None:
         # Our chatbot is not very smart right now...
         answer = "I don't know!"
         self.chat_history.append((self.question, answer))
 
-    def answer2(self):
+    def answer2(self) -> None:
         # Our chatbot is not very smart right now...
         answer = "I don't know!"
         self.chat_history.append((self.question, answer))


### PR DESCRIPTION
This pull request introduces type hinting improvements and import optimizations in the `tutorial_utils.py` file. It adds the `from __future__ import annotations` statement at the beginning of the file to enable postponed evaluation of annotations. The `openai` import is moved after the `os` import for better organization. Additionally, return type annotations (`-> None`) are added to the `answer` and `answer2` methods in the `ChatappState` class to enhance type clarity.
