### PR TITLE
TODO: Refactor pricing page boolean logic to use enums

### DIFF
--- a/pcweb/pages/pricing.py
+++ b/pcweb/pages/pricing.py
@@ -167,6 +167,8 @@ def form() -> rx.Component:
     )
 
 
+# TODO(elvis): refactor the boolean logic to use enums
+# https://linear.app/reflex-dev/issue/ENG-3837/refactor-the-included-variable-param-on-our-pricing-page-to-use-enums
 def features(text: str, included: bool) -> rx.Component:
     if included:
         return rx.hstack(


### PR DESCRIPTION
This pull request adds a TODO comment in the `pricing.py` file. The comment suggests refactoring the boolean logic in the `features` function to use enums instead. It also includes a link to a Linear issue (ENG-3837) for tracking this proposed refactoring task.
