### PR TITLE
fix: Remove period from newsletter text

### DIFF
--- a/pcweb/components/webpage/footer.py
+++ b/pcweb/components/webpage/footer.py
@@ -166,7 +166,7 @@ def news_letter(align="left"):
     return rx.vstack(
         rx.text("Join Newsletter", color="#E8E8F4", style=footer_item_style),
         rx.text(
-            "Get the latest updates and news about Reflex.",
+            "Get the latest updates and news about Reflex",
             color="#6C6C81",
             font_size="0.8em",
         ),

--- a/pcweb/pages/index/components/news_letter.py
+++ b/pcweb/pages/index/components/news_letter.py
@@ -15,7 +15,7 @@ def news_letter_text() -> rx.Component:
             class_name="inline-block bg-clip-text bg-gradient-to-r from-slate-12 to-slate-11 w-full text-start text-transparent",
         ),
         rc.text(
-            " Get the latest updates and news about Reflex.",
+            " Get the latest updates and news about Reflex",
             text_align="left",
             color="var(--c-slate-10)",
             font_weight="bold",

--- a/pcweb/views/footer.py
+++ b/pcweb/views/footer.py
@@ -71,7 +71,7 @@ def newsletter_form() -> rx.Component:
                 class_name="font-instrument-sans font-semibold text-slate-12 text-sm leading-tight",
             ),
             rx.text(
-                "Get the latest updates and news about Reflex.",
+                "Get the latest updates and news about Reflex",
                 class_name="font-small text-slate-9",
             ),
             rx.cond(


### PR DESCRIPTION
This pull request removes the trailing period from the newsletter subscription text across multiple components. The change ensures consistency in the newsletter description, which now reads "Get the latest updates and news about Reflex" without a period at the end. This minor adjustment affects the footer, index page, and newsletter form components.
