### PR TITLE
Update badge text to "pip install reflex"

### DIFF
--- a/pcweb/components/webpage/badge.py
+++ b/pcweb/components/webpage/badge.py
@@ -6,7 +6,7 @@ from pcweb.components.hint import hint
 @rx.memo
 def badge() -> rx.Component:
     return hint(
-        text="This entire website was made with Reflex!",
+        text="pip install reflex",
         content=rx.link(
             get_icon("badge_logo"),
             rx.text(


### PR DESCRIPTION
This pull request updates the text displayed in the badge component. The previous text, "This entire website was made with Reflex!", has been replaced with "pip install reflex". This change provides a more direct call-to-action for users interested in using Reflex, emphasizing the installation command.
