### PR TITLE
Rename "news_letter" to "newsletter" throughout codebase

### DIFF
--- a/pcweb/components/webpage/footer.py
+++ b/pcweb/components/webpage/footer.py
@@ -119,7 +119,7 @@ button_style = {
 }
 
 
-def news_letter_form():
+def newsletter_form():
     return rx.el.form(
         rc.input_group(
             rc.input_right_element(
@@ -162,7 +162,7 @@ def message_group():
     )
 
 
-def news_letter(align="left"):
+def newsletter(align="left"):
     return rx.vstack(
         rx.text("Join Newsletter", color="#E8E8F4", style=footer_item_style),
         rx.text(
@@ -173,7 +173,7 @@ def news_letter(align="left"):
         rx.cond(
             IndexState.signed_up,
             message_group(),
-            news_letter_form(),
+            newsletter_form(),
         ),
         align_items=align,
         width="100%",
@@ -250,7 +250,7 @@ def links():
             )
         ),
         rx.tablet_and_desktop(
-            news_letter(),
+            newsletter(),
         ),
         justify="between",
         align_items="top",
@@ -266,7 +266,7 @@ def footer(style=footer_style):
             installation(),
             links(),
             rx.mobile_only(
-                news_letter(),
+                newsletter(),
                 width="100%",
             ),
             rx.hstack(

--- a/pcweb/constants.py
+++ b/pcweb/constants.py
@@ -1,4 +1,5 @@
 # pcweb constants.
+API_BASE_URL_LOOPS: str = "https://app.loops.so/api/v1"
 
 # pcweb urls.
 REFLEX_URL = "https://reflex.dev/"

--- a/pcweb/pages/index/components/news_letter.py
+++ b/pcweb/pages/index/components/news_letter.py
@@ -4,10 +4,10 @@ from pcweb.signup import IndexState
 import reflex_chakra as rc
 
 
-def news_letter_text() -> rx.Component:
+def newsletter_text() -> rx.Component:
     return rx.vstack(
         rc.text(
-            "Join Our Newsletter!",
+            "Join our newsletter!",
             text_align="left",
             font_size=["20px", "20px", "28px", "42px", "42px", "42px"],
             font_weight="bold",
@@ -15,7 +15,7 @@ def news_letter_text() -> rx.Component:
             class_name="inline-block bg-clip-text bg-gradient-to-r from-slate-12 to-slate-11 w-full text-start text-transparent",
         ),
         rc.text(
-            " Get the latest updates and news about Reflex",
+            "Get the latest updates and news about Reflex",
             text_align="left",
             color="var(--c-slate-10)",
             font_weight="bold",
@@ -31,7 +31,7 @@ def news_letter_text() -> rx.Component:
 def message_group():
     return rx.vstack(
         rc.text(
-            "Welcome to the Reflex Community!",
+            "Welcome to the Reflex community!",
             text_align="left",
             background_image="linear-gradient(95deg, #D6D6ED 42.14%, #727280 63.21%)",
             font_size=["12px", "15px", "22px", "28px", "35px", "35px"],
@@ -49,7 +49,7 @@ def message_group():
     )
 
 
-def news_letter_form() -> rx.Component:
+def newsletter_form() -> rx.Component:
     return rx.el.form(
         rc.input_group(
             rc.input_right_element(
@@ -85,14 +85,14 @@ def news_letter_form() -> rx.Component:
     )
 
 
-def news_letter_section() -> rx.Component:
+def newsletter_section() -> rx.Component:
     return rx.center(
         rx.cond(
             IndexState.signed_up,
             message_group(),
             rx.vstack(
-                news_letter_text(),
-                news_letter_form(),
+                newsletter_text(),
+                newsletter_form(),
                 width="80%",
             ),
         ),

--- a/pcweb/pages/index/views/footer_index.py
+++ b/pcweb/pages/index/views/footer_index.py
@@ -110,7 +110,7 @@ def newletter_input() -> rx.Component:
     )
 
 
-def news_letter() -> rx.Component:
+def newsletter() -> rx.Component:
     return (
         rx.box(
             rx.text(
@@ -165,7 +165,7 @@ def footer_index() -> rx.Component:
                 menu_socials(),
                 class_name="flex flex-col items-center lg:items-start gap-4 self-stretch p-10",
             ),
-            news_letter(),
+            newsletter(),
             class_name="grid grid-cols-1 lg:grid-cols-3 gap-0 grid-rows-2 w-full divide-y divide-slate-3 lg:divide-x border-t border-slate-3 lg:border-t-0",
         ),
         class_name="flex max-w-[64.19rem] justify-center items-center w-full",

--- a/pcweb/signup.py
+++ b/pcweb/signup.py
@@ -1,11 +1,12 @@
 import reflex as rx
 
+from pcweb.constants import API_BASE_URL_LOOPS
 from datetime import datetime
 from sqlmodel import Field
 import os
 import json
 import httpx
-from email_validator import EmailNotValidError, validate_email
+from email_validator import EmailNotValidError, validate_email, ValidatedEmail
 from sqlmodel import Field
 
 
@@ -17,25 +18,35 @@ class Waitlist(rx.Model, table=True):
 class IndexState(rx.State):
     """Hold the state for the home page."""
 
-    # Whether the user signed up for the waitlist.
+    # Whether the user signed up for the newsletter.
     signed_up: bool = False
 
     # Whether to show the confetti.
     show_confetti: bool = False
 
-    def add_contact_to_loops(self, contact_data):
-        url = "https://app.loops.so/api/v1/contacts/create"
-        loops_api_key = os.getenv("LOOPS_API_KEY")
+    def add_contact_to_loops(
+        self,
+        email: str,
+    ):
+        url: str = f"{API_BASE_URL_LOOPS}/contacts/create"
+        loops_api_key: str | None = os.getenv("LOOPS_API_KEY")
         if loops_api_key is None:
             print("Loops API key does not exist")
+            return
+
         headers = {
             "Accept": "application/json",
             "Authorization": f"Bearer {loops_api_key}",
         }
-
         try:
             with httpx.Client() as client:
-                response = client.post(url, headers=headers, json=contact_data)
+                response = client.post(
+                    url,
+                    headers=headers,
+                    json={
+                            "email": email,
+                        },
+                )
                 response.raise_for_status()  # Raise an exception for HTTP errors (4xx and 5xx)
 
         except httpx.HTTPError as e:
@@ -44,34 +55,42 @@ class IndexState(rx.State):
     def signup_for_another_user(self):
         self.signed_up = False
 
-    def signup(self, form_data: dict[str, str]):
-        """Sign the user up for the waitlist."""
+    def signup(
+        self,
+        form_data: dict[str, str],
+    ):
+        """Sign the user up for the newsletter."""
+        email: str | None = None
+        if email_to_validate := form_data.get("input_email"):
+            try:
+                validated_email: ValidatedEmail = validate_email(
+                    email_to_validate,
+                    check_deliverability=True,
+                )
+                email = validated_email.normalized
 
-        email = form_data.get("input_email", None)
-        if not email:
-            return
+            except EmailNotValidError as e:
+                # Alert the error message.
+                return rx.toast.warning(
+                    str(e),
+                    style={
+                        "border": "1px solid #3C3646",
+                        "background": "linear-gradient(218deg, #1D1B23 -35.66%, #131217 100.84%)",
+                    },
+                )
 
-        try:
-            validation = validate_email(email, check_deliverability=True)
-            email = validation.email
-        except EmailNotValidError as e:
-            # Alert the error message.
-            return rx.toast.warning(
-                str(e),
-                style={
-                    "border": "1px solid #3C3646",
-                    "background": "linear-gradient(218deg, #1D1B23 -35.66%, #131217 100.84%)",
-                },
-            )
-
-        # Check if the user is already on the waitlist.
+        self.add_contact_to_loops(email)
+        # Check if the user is already on the newsletter
         with rx.session() as session:
             user = session.query(Waitlist).filter(Waitlist.email == email).first()
             if user is None:
-                # Add the user to the waitlist.
-                session.add(Waitlist(email=email))
+                # Add the user to the newsletter
+                session.add(
+                    Waitlist(
+                        email=email,
+                    ),
+                )
                 session.commit()
-                contact_data = json.dumps({"email": email})
-                self.add_contact_to_loops(contact_data)
 
         self.signed_up = True
+        return None


### PR DESCRIPTION
This pull request renames the "news_letter" functions and components to "newsletter" across multiple files for consistency. It also makes minor text adjustments in the newsletter-related components, such as changing "Join Our Newsletter!" to "Join our newsletter!" and "Welcome to the Reflex Community!" to "Welcome to the Reflex community!". These changes improve code readability and maintain a consistent naming convention throughout the project.
