### PR TITLE
Disable tracking pixels in non-production mode

### DIFF
--- a/pcweb/telemetry/pixels.py
+++ b/pcweb/telemetry/pixels.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import itertools
 from typing import TYPE_CHECKING
 
+from reflex.utils.exec import is_prod_mode
+
 if TYPE_CHECKING:
     import reflex as rx
 
@@ -16,6 +18,9 @@ from pcweb.telemetry import (
 
 
 def get_pixel_website_trackers() -> list[rx.Component]:
+    if not is_prod_mode():
+        return []
+
     return list(
         itertools.chain(
             pixels_google.get_pixel_website_trackers(),


### PR DESCRIPTION
This pull request adds a production mode check to the `get_pixel_website_trackers()` function in the `pcweb/telemetry/pixels.py` file. The function now returns an empty list when not in production mode, preventing website trackers from being added in non-production environments. This change helps to avoid unnecessary tracking during development and testing.
