### PR TITLE
Update Trunk CLI and linter versions

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -31,6 +31,7 @@ lint:
     - actionlint@1.7.2
     - checkov@3.2.255
     - git-diff-check
+    - isort@5.13.2
     - markdownlint@0.42.0
     - osv-scanner@1.8.5
     - oxipng@9.1.2
@@ -48,7 +49,6 @@ lint:
     - bandit
     - black
     - flake8
-    - isort
     - markdown-link-check
     - mypy
     - prettier

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -3,7 +3,7 @@
 version: 0.1
 
 cli:
-  version: 1.22.4
+  version: 1.22.5
 
 # Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
 plugins:
@@ -28,20 +28,20 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - actionlint@1.7.1
-    - checkov@3.2.242
+    - actionlint@1.7.2
+    - checkov@3.2.255
     - git-diff-check
-    - markdownlint@0.41.0
-    - osv-scanner@1.8.4
+    - markdownlint@0.42.0
+    - osv-scanner@1.8.5
     - oxipng@9.1.2
-    - pyright@1.1.378
-    - ruff@0.6.3
+    - pyright@1.1.382
+    - ruff@0.6.7
     - shellcheck@0.10.0
     - shfmt@3.6.0
     - svgo@3.3.2
     - taplo@0.9.3
-    - trivy@0.54.1
-    - trufflehog@3.81.10
+    - trivy@0.55.2
+    - trufflehog@3.82.5
     - yamllint@1.35.1
 
   disabled:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -13,7 +13,7 @@ plugins:
       uri: https://github.com/trunk-io/plugins
 
     - id: oss-linter-trunk
-      ref: v0.2024.09.03.12.59
+      ref: v0.2024.09.26.13.04
       uri: https://github.com/reflex-dev/oss-linter-trunk
 
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)


### PR DESCRIPTION
This pull request updates the Trunk configuration file with the following changes:

1. Upgrades the Trunk CLI version to 1.22.5
2. Updates the oss-linter-trunk plugin to version v0.2024.09.26.13.04
3. Updates several linter versions:
   - actionlint to 1.7.2
   - checkov to 3.2.255
   - markdownlint to 0.42.0
   - osv-scanner to 1.8.5
   - pyright to 1.1.382
   - ruff to 0.6.7
   - trivy to 0.55.2
   - trufflehog to 3.82.5
4. Adds isort version 5.13.2 to the enabled linters
5. Removes isort from the disabled linters list

These updates ensure that the project is using the latest versions of the Trunk CLI, plugins, and linters, potentially bringing improvements in functionality, performance, and security.
