### PR TITLE
Add webhook for general feedback form

### DIFF
--- a/pcweb/constants.py
+++ b/pcweb/constants.py
@@ -5,6 +5,7 @@ REFLEX_DEV_WEB_LANDING_FORM_DEMO_FORM_WEBHOOK_URL = "https://hkdk.events/hiet6t6
 REFLEX_DEV_WEB_NEWSLETTER_FORM_WEBHOOK_URL: str = "https://hkdk.events/t0qopjbznnp2fr"
 REFLEX_DEV_WEB_LANDING_FORM_SALES_CALL_WEBHOOK_URL: str = "https://hkdk.events/fl9kcr4bf5pn7w"
 REFLEX_DEV_WEB_PRICING_FORM_PRO_PLAN_WAITLIST_WEBHOOK_URL: str = "https://hkdk.events/amh01aq0hojled"
+REFLEX_DEV_WEB_GENERAL_FORM_FEEDBACK_WEBHOOK_URL: str = "https://hkdk.events/8woee5brmxqwdr"
 
 # pcweb urls.
 REFLEX_URL = "https://reflex.dev/"

--- a/pcweb/templates/docpage/state.py
+++ b/pcweb/templates/docpage/state.py
@@ -1,12 +1,16 @@
 """The state for the navbar component."""
 
+import contextlib
 import os
 from datetime import datetime
 from typing import Any, Optional, Set
 
+import httpx
 import reflex as rx
 import requests
 from sqlmodel import Field
+
+from pcweb.constants import REFLEX_DEV_WEB_GENERAL_FORM_FEEDBACK_WEBHOOK_URL
 
 
 class Feedback(rx.Model, table=True):
@@ -35,7 +39,12 @@ class FeedbackState(rx.State):
                 close_button=True,
             )
 
-        current_page_route = self.router.page.raw_path
+        current_page_route: str = self.router.page.raw_path
+        with contextlib.suppress(httpx.HTTPError) and httpx.Client() as client:
+            client.post(
+                REFLEX_DEV_WEB_GENERAL_FORM_FEEDBACK_WEBHOOK_URL,
+                json=form_data,
+            )
 
         discord_message = f"""
 Contact: {email}


### PR DESCRIPTION
This pull request adds a new webhook URL for general form feedback and enhances the feedback submission process. 

Key changes:
- Added a new constant `REFLEX_DEV_WEB_GENERAL_FORM_FEEDBACK_WEBHOOK_URL` in `pcweb/constants.py`.
- Updated the `FeedbackState` class in `pcweb/templates/docpage/state.py` to send feedback data to the new webhook URL.
- Implemented error handling using `contextlib.suppress` to gracefully handle potential HTTP errors during the webhook POST request.
- Improved the feedback submission process by including the current page route in the submitted data.

These changes will enable better tracking and processing of user feedback across the platform.