### PR TITLE
Add whitespace in whitelist checking function

### DIFF
--- a/pcweb/whitelist.py
+++ b/pcweb/whitelist.py
@@ -10,7 +10,8 @@
 # - Incorrect: WHITELISTED_PAGES = ["/docs/getting-started/introduction/"]
 
 WHITELISTED_PAGES = []
-  
+
+
 def _check_whitelisted_path(path):
     if len(WHITELISTED_PAGES) == 0:
         return True
@@ -25,4 +26,5 @@ def _check_whitelisted_path(path):
     for whitelisted_path in WHITELISTED_PAGES:
         if path.startswith(whitelisted_path):
             return True
+
     return False


### PR DESCRIPTION
This pull request makes minor formatting changes to the `pcweb/whitelist.py` file. It adds an extra blank line after the `WHITELISTED_PAGES` list definition and another blank line before the `return False` statement at the end of the `_check_whitelisted_path` function. These changes improve code readability and adhere to PEP 8 style guidelines for Python code.
