### PR TITLE
Refactor Inkeep search configuration and add constants

### DIFF
--- a/pcweb/components/docpage/navbar/inkeep.py
+++ b/pcweb/components/docpage/navbar/inkeep.py
@@ -1,5 +1,6 @@
 """UI and logic inkeep chat component."""
 
+import itertools
 from typing import List, Set
 
 import reflex as rx
@@ -7,38 +8,7 @@ from reflex.event import EventHandler
 from reflex.utils.imports import ImportVar
 from reflex.vars import Var
 
-
-class Search(rx.Component):
-    tag = "SearchBar"
-
-    special_props: List[Var] = [
-        Var.create(
-            "{...searchBarProps}",
-            _var_is_string=False,
-        ),
-    ]
-
-    is_open: Var[bool] = False
-
-    on_close: EventHandler[lambda: []]
-
-    on_shortcut_key_pressed: EventHandler[lambda: []]
-
-    class_name: Var[str] = "max-w-[256px] max-h-[32px]"
-
-    def add_imports(self):
-        """Add the imports for the component."""
-        return {
-            "next/dynamic": {ImportVar(tag="dynamic", is_default=True)},
-            "react": {ImportVar(tag="useContext")},
-            "/utils/context": {ImportVar(tag="ColorModeContext")},
-        }
-
-    def add_hooks(self):
-        """Add the hooks for the component."""
-        return [
-            "const { resolvedColorMode } = useContext(ColorModeContext)",
-            """const SearchBar = dynamic(
+JS_SNIPPET_INKEEP_SEARCH: str = """const SearchBar = dynamic(
   () => import('@inkeep/uikit').then((mod) => mod.InkeepSearchBar),
   {
     ssr: false,
@@ -47,11 +17,11 @@ class Search(rx.Component):
 const searchBarProps = {
   stylesheetUrls: ['/inkeepstyle-docs.css'],
   baseSettings: {
-    apiKey: '87b7469f79014c35a3313795088151a52de8a58a547abd16',
-    integrationId: 'clkbf9e7e0001s601sa0ciax1',
+    apiKey: 'reflex_inkeep_api_key',
+    integrationId: 'refelx_inkeep_integration_id',
     customIcons: {search: {custom: "/icons/search.svg"}},
-    organizationId: 'org_WQKeNdnuPGEfuUhC',
-    organizationDisplayName: 'Reflex',
+    organizationId: 'reflex_inkeep_organization_id',
+    organizationDisplayName: 'reflex_inkeep_organization_display_name',
     primaryBrandColor: '#6E56CF',
     breadcrumbRules: {
       urlToBreadcrumbMapper: [
@@ -118,7 +88,71 @@ const searchBarProps = {
       'Where can I deploy my apps?',
     ],
   },
-};""",
+};"""
+
+REFLEX_INKEEP_API_KEY: str = "87b7469f79014c35a3313795088151a52de8a58a547abd16"
+REFLEX_INKEEP_INTEGRATION_ID: str = "clkbf9e7e0001s601sa0ciax1"
+REFLEX_INKEEP_ORORGANIZATION_ID: str = "org_WQKeNdnuPGEfuUhC"
+REFLEX_INKEEP_ORGANIZATION_DISPLAY_NAME: str = "Reflex"
+
+
+def get_js_snippet_inkeep_search() -> str:
+    replacements: tuple[tuple[str, str]] = (
+        (
+            "reflex_inkeep_api_key",
+            REFLEX_INKEEP_API_KEY,
+        ),
+        (
+            "reflex_inkeep_integration_id",
+            REFLEX_INKEEP_INTEGRATION_ID,
+        ),
+        (
+            "reflex_inkeep_organization_id",
+            REFLEX_INKEEP_ORORGANIZATION_ID,
+        ),
+        (
+            "reflex_inkeep_organization_display_name",
+            REFLEX_INKEEP_ORGANIZATION_DISPLAY_NAME,
+        ),
+    )
+    return itertools.reduce(
+        lambda s, kv: s.replace(*kv),
+        replacements,
+        JS_SNIPPET_INKEEP_SEARCH,
+    )
+
+
+class Search(rx.Component):
+    tag = "SearchBar"
+
+    special_props: List[Var] = [
+        Var.create(
+            "{...searchBarProps}",
+            _var_is_string=False,
+        ),
+    ]
+
+    is_open: Var[bool] = False
+
+    on_close: EventHandler[lambda: []]
+
+    on_shortcut_key_pressed: EventHandler[lambda: []]
+
+    class_name: Var[str] = "max-w-[256px] max-h-[32px]"
+
+    def add_imports(self):
+        """Add the imports for the component."""
+        return {
+            "next/dynamic": {ImportVar(tag="dynamic", is_default=True)},
+            "react": {ImportVar(tag="useContext")},
+            "/utils/context": {ImportVar(tag="ColorModeContext")},
+        }
+
+    def add_hooks(self):
+        """Add the hooks for the component."""
+        return [
+            "const { resolvedColorMode } = useContext(ColorModeContext)",
+            JS_SNIPPET_INKEEP_SEARCH,
         ]
 
 


### PR DESCRIPTION
This pull request refactors the Inkeep search component implementation in the documentation navbar. Key changes include:

1. Extracted the JavaScript snippet for Inkeep search configuration into a separate constant `JS_SNIPPET_INKEEP_SEARCH`.

2. Introduced new constants for Inkeep API key, integration ID, organization ID, and organization display name.

3. Implemented a `get_js_snippet_inkeep_search()` function to dynamically replace placeholder values in the JavaScript snippet with actual configuration values.

4. Updated the `Search` component's `add_hooks()` method to use the new `JS_SNIPPET_INKEEP_SEARCH` constant instead of an inline string.

These changes improve code organization, make it easier to update Inkeep configuration, and enhance maintainability of the search component.
