### PR TITLE
Remove production mode check for pixel website trackers

### DIFF
--- a/pcweb/telemetry/pixels.py
+++ b/pcweb/telemetry/pixels.py
@@ -18,9 +18,6 @@ from pcweb.telemetry import (
 
 
 def get_pixel_website_trackers() -> list[rx.Component]:
-    if not is_prod_mode():
-        return []
-
     return list(
         itertools.chain(
             pixels_google.get_pixel_website_trackers(),


### PR DESCRIPTION
This change removes the production mode check from the `get_pixel_website_trackers` function in the `pixels.py` file. As a result, website trackers will now be returned regardless of the environment, allowing for consistent tracking behavior across all modes.
