### PR TITLE
Capitalize "Python" in Bayesline case study description

### DIFF
--- a/case-studies/bayesline.md
+++ b/case-studies/bayesline.md
@@ -1,6 +1,6 @@
 ---
 company: Bayesline
-description: "Why Bayesline chose Reflex over Dash Plotly for their production-grade python web app"
+description: "Why Bayesline chose Reflex over Dash Plotly for their production-grade Python web app"
 domain: "https://bayesline.com/"
 founded: "New York, 2024"
 investors: "Y Combinator"

--- a/case-studies/bayesline.md
+++ b/case-studies/bayesline.md
@@ -63,7 +63,6 @@ Bayesline deploys customized equity factor risk (ML) models in the cloud, which 
 Sebastian Janisch, the Bayesline co-founder, led the technical team and worked previously at Bloomberg and BlackRock, where he was a Director in their Financial Modeling Group.
 Here is a [blog](https://bayesline.com/blog/building-risk-models) that explains what Bayesline does in detail (The images and demos are all Reflex apps).
 
-
 ## How Bayesline struggled with Plotly Dash
 
 Quantitative Analysts (Quants), like Sebastian, are usually proficient in data-oriented programming languages like Python.
@@ -135,7 +134,6 @@ Turns out I don’t see right now, as it stands at least, reasons to migrate fro
 
 Bayesline has since scaled from a prototype to a full fledged production app with paid trials.
 The team continues to build and deploy data-intensive apps using Reflex.
-
 
 ## What Bayesline gained from using Reflex
 

--- a/case-studies/bayesline.md
+++ b/case-studies/bayesline.md
@@ -1,6 +1,6 @@
 ---
 company: Bayesline
-description: "Why Bayesline chose Reflex over Dash Plotly for their production-grade Python web app"
+description: "Why Bayesline chose Reflex over Plotly Dash for their production-grade Python web app"
 domain: "https://bayesline.com/"
 founded: "New York, 2024"
 investors: "Y Combinator"


### PR DESCRIPTION
This pull request updates the description in the Bayesline case study. It corrects the capitalization of "Python" in the description, changing it from "python" to "Python" for proper noun consistency.
