### PR TITLE
Replace Common Room and Instantly pixels with Koala pixel

### DIFF
--- a/pcweb/telemetry/pixels.py
+++ b/pcweb/telemetry/pixels.py
@@ -3,11 +3,6 @@ from __future__ import annotations
 import itertools
 from typing import TYPE_CHECKING
 
-from reflex.utils.exec import is_prod_mode
-
-if TYPE_CHECKING:
-    import reflex as rx
-
 from pcweb.telemetry import (
     pixels_clearbit,
     pixels_common_room,
@@ -15,6 +10,10 @@ from pcweb.telemetry import (
     pixels_instantly,
     pixels_posthog,
 )
+
+if TYPE_CHECKING:
+    import reflex as rx
+
 
 
 def get_pixel_website_trackers() -> list[rx.Component]:

--- a/pcweb/telemetry/pixels.py
+++ b/pcweb/telemetry/pixels.py
@@ -3,13 +3,7 @@ from __future__ import annotations
 import itertools
 from typing import TYPE_CHECKING
 
-from pcweb.telemetry import (
-    pixels_clearbit,
-    pixels_common_room,
-    pixels_google,
-    pixels_instantly,
-    pixels_posthog,
-)
+from pcweb.telemetry import pixels_clearbit, pixels_google, pixels_koala, pixels_posthog
 
 if TYPE_CHECKING:
     import reflex as rx
@@ -20,9 +14,10 @@ def get_pixel_website_trackers() -> list[rx.Component]:
     return list(
         itertools.chain(
             pixels_google.get_pixel_website_trackers(),
-            pixels_common_room.get_pixel_website_trackers(),
+            # pixels_common_room.get_pixel_website_trackers(),
+            pixels_koala.get_pixel_website_trackers(),
             pixels_posthog.get_pixel_website_trackers(),
             pixels_clearbit.get_pixel_website_trackers(),
-            pixels_instantly.get_pixel_website_trackers(),
+            # pixels_instantly.get_pixel_website_trackers(),
         ),
     )

--- a/pcweb/telemetry/pixels_koala.py
+++ b/pcweb/telemetry/pixels_koala.py
@@ -1,0 +1,12 @@
+from typing import Generator
+
+import reflex as rx
+
+PIXEL_SCRIPT_KOALA: str = """
+!function(t){if(window.ko)return;window.ko=[],["identify","track","removeListeners","on","off","qualify","ready"].forEach(function(t){ko[t]=function(){var n=[].slice.call(arguments);return n.unshift(t),ko.push(n),ko}});var n=document.createElement("script");n.async=!0,n.setAttribute("src","https://cdn.getkoala.com/v1/pk_733c6bff981543743bd2d53b4d7e95cc9b3f/sdk.js"),(document.body || document.head).appendChild(n)}();
+"""
+
+def get_pixel_website_trackers()-> Generator[rx.Component, None, None]:
+    yield rx.script(
+        PIXEL_SCRIPT_KOALA,
+    )


### PR DESCRIPTION
This pull request replaces Common Room and Instantly tracking pixels with Koala in the website trackers. It introduces a new file `pixels_koala.py` that contains the Koala tracking script and a function to generate the corresponding React component. The `get_pixel_website_trackers()` function in `pixels.py` has been updated to include Koala and remove Common Room and Instantly trackers.
