### PR TITLE
Only show overriden props

### DIFF
--- a/pcweb/pages/docs/component.py
+++ b/pcweb/pages/docs/component.py
@@ -149,7 +149,9 @@ class Source(Base):
 
         parent_cls = self.component.__bases__[0]
         if parent_cls != rx.Component and parent_cls != BaseHTML:
-            props += Source(component=parent_cls).get_props()
+            parent_props = Source(component=parent_cls).get_props()
+            # filter out the props that have been overridden in the parent class.
+            props += [prop for prop in parent_props if prop.name not in {p.name for p in props}]
 
         return props
 


### PR DESCRIPTION
When a prop in a child class overrides that in a parent class, we should only show the overridden prop.

Currently, the prop docs for `rx.list` in this PR, https://github.com/reflex-dev/reflex/pull/4183 adds the signature of the parent prop as a duplicate:

![Screenshot 2024-10-23 at 2 32 31 PM](https://github.com/user-attachments/assets/8da4c21a-6b1a-47d8-9f26-47ec5dbd6818)

This PR fixes that:

![Screenshot 2024-10-23 at 2 29 54 PM](https://github.com/user-attachments/assets/ba98015c-13e2-4c59-ae04-ea7eb3dbe28d)
