### PR TITLE
[DOCS] Update pseudo style prop for chakra ui link.

### DIFF
--- a/docs/styling/overview.md
+++ b/docs/styling/overview.md
@@ -232,7 +232,7 @@ With this configuration, Tailwind will be disabled, and no Tailwind styles will 
 
 ## Special Styles
 
-We support all of Chakra UI's [pseudo styles]({"https://chakra-ui.com/docs/features/style-props#pseudo"}).
+We support all of Chakra UI's [pseudo styles]({"https://v2.chakra-ui.com/docs/styled-system/style-props#pseudo"}).
 
 Below is an example of text that changes color when you hover over it.
 


### PR DESCRIPTION
The link for the documentation of Chakra UI for pseudo style prop has been updated. This PR changes that in the documentations. 

The current url points to a 404.
![image](https://github.com/user-attachments/assets/4cb9f991-b836-450c-a3b7-3bd22415d8be)
