### PR TITLE
nginx.conf tweaks: return 404 page when not found

### DIFF
--- a/blog/2024-10-8-self-hosting-reflex-with-docker.md
+++ b/blog/2024-10-8-self-hosting-reflex-with-docker.md
@@ -205,6 +205,7 @@ server {
  server_name frontend;
 
 
+ error_page   404  /404.html;
  error_page   500 502 503 504  /50x.html;
  location = /50x.html {
     root   /usr/share/nginx/html;
@@ -228,7 +229,7 @@ server {
  location / {
    # This would be the directory where your Reflex app's static files are stored at
    root /usr/share/nginx/html;
-   try_files $uri /$uri/index.html;
+   try_files $uri $uri/index.html =404;
  }
 
 }

--- a/blog/2024-10-8-self-hosting-reflex-with-docker.md
+++ b/blog/2024-10-8-self-hosting-reflex-with-docker.md
@@ -206,10 +206,6 @@ server {
 
 
  error_page   404  /404.html;
- error_page   500 502 503 504  /50x.html;
- location = /50x.html {
-    root   /usr/share/nginx/html;
- }
 
  location /_event {
     proxy_set_header   Connection "upgrade";
@@ -229,7 +225,6 @@ server {
  location / {
    # This would be the directory where your Reflex app's static files are stored at
    root /usr/share/nginx/html;
-   try_files $uri $uri/index.html =404;
  }
 
 }


### PR DESCRIPTION
avoid returning a 500 error due to internal rewrite loop, which blocks/breaks dynamic routes