### PR TITLE
only recommend `psycopg[binary]` package

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -199,14 +199,7 @@ error_message(
     heading="ImportError: couldn't import psycopg",
     error_code="ImportError: couldn't import psycopg 'python' implementation: libpq library not found | couldn't import psycopg 'binary' implementation: No module named 'psycopg_binary' | couldn't import psycopg 'c' implementation: No module named 'psycopg_c'",
     solution=[
-        h4_comp_error(text="This is caused by not installing the correct psycopg package. Solution is to add the following packages to your requirements.txt file."),
-        rx.el.ul(
-            rx.el.li("psycopg2-binary==2.9.9"),
-            rx.el.li("psycopg-binary==3.2.3"),
-rx.el.li("psycopg==3.2.3"),
-rx.el.li("psycopg-pool==3.2.3"),
-            class_name="list-disc pl-4",
-        ),
+        h4_comp_error(text="This is caused by not installing the correct psycopg package. Solution is to add the `psycopg[binary]==3.2.3` package to your requirements.txt file."),
     ],
     error_type="Import Error",
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 email-validator==2.1.1
 black==23.10.0
 pandas>=1.5.3
-psycopg2-binary==2.9.9
+psycopg[binary]==3.2.3
 plotly-express==0.4.1
 googletrans-py==4.0.0
 typesense==0.14.0


### PR DESCRIPTION
this is the only package needed to successfully access a postgres db.

i've confirmed this in `form-designer` and `rx-shout`, both of which use postgres and neither of which install anything other than this library in a fresh docker container or deploy.

follow up to #1154

also update reflex-web requirements to follow our own advice, seems to work just fine 😀