### PR TITLE
[ENG-4188] set GitHub stars default during app build

### DIFF
--- a/pcweb/github.py
+++ b/pcweb/github.py
@@ -6,8 +6,16 @@ import httpx
 import reflex as rx
 import contextlib
 
-REFLEX_STAR_COUNT = 0
 GITHUB_API_URL = "https://api.github.com/repos/reflex-dev/reflex"
+
+
+def get_stars_on_build():
+    """Fetch the stars when app is built as default"""
+    data = httpx.get(GITHUB_API_URL).json()
+    return int(data["stargazers_count"])
+
+
+REFLEX_STAR_COUNT = get_stars_on_build()
 
 
 async def fetch_count():


### PR DESCRIPTION
maybe setting the `fetch` method to the variable will get the latest star count as default and will show as the temp placeholder instead of `0K`