### PR TITLE
Add type hints to Image component documentation

### DIFF
--- a/docs/library/media/image.md
+++ b/docs/library/media/image.md
@@ -41,8 +41,8 @@ import requests
 
 
 class ImageState(rx.State):
-    url = f"https://picsum.photos/id/1/200/300"
-    image = Image.open(requests.get(url, stream=True).raw)
+    url: str = f"https://picsum.photos/id/1/200/300"
+    image: Image.Image = Image.open(requests.get(url, stream=True).raw)
 
 
 def image_pil_example():


### PR DESCRIPTION
If the source of the image is from the PIL package, the type hint must be "Image.Image". It is easy to mistake it for simply "Image" which results in the following error: TypeError: Unsupported type <module 'PIL.Image'>. This simple type hint on the documentation resolves any confusion.