### PR TITLE
Add a demo for using a `Select` component within a `Drawer` (requires `position="popper"`)

### DIFF
--- a/docs/library/forms/select.md
+++ b/docs/library/forms/select.md
@@ -174,3 +174,30 @@ def select_form_example():
         width="50%",
     )
 ```
+
+
+### Using Select within a Drawer component
+
+If using within a [Drawer](../../overlay/drawer/) component, set the `position` prop to `"popper"` to ensure the select menu is displayed correctly.
+
+```python demo
+rx.drawer.root(
+    rx.drawer.trigger(rx.button("Open Drawer")),
+    rx.drawer.overlay(z_index="5"),
+    rx.drawer.portal(
+        rx.drawer.content(
+            rx.vstack(
+                rx.drawer.close(rx.box(rx.button("Close"))),
+                rx.select(["apple", "grape", "pear"], default_value="apple", position="popper"),
+            ),
+            top="auto",
+            right="auto",
+            height="100%",
+            width="20em",
+            padding="2em",
+            background_color="#FFF",
+        ),
+    ),
+    direction="left",
+)
+```

--- a/docs/library/forms/select.md
+++ b/docs/library/forms/select.md
@@ -188,14 +188,11 @@ rx.drawer.root(
         rx.drawer.content(
             rx.vstack(
                 rx.drawer.close(rx.box(rx.button("Close"))),
-                rx.select(["apple", "grape", "pear"], default_value="apple", position="popper"),
+                rx.select(["apple", "grape", "pear"], position="popper"),
             ),
-            top="auto",
-            right="auto",
-            height="100%",
             width="20em",
             padding="2em",
-            background_color="#FFF",
+            background_color=rx.color("gray", 1),
         ),
     ),
     direction="left",


### PR DESCRIPTION
I had some trouble using the `rx.select` component within a drawer since a recent update to react . Setting the position to "popper" fixes it. Thought I'd just add a quick example to the docs so it's easier to find in the future.

Related to: https://github.com/reflex-dev/reflex/issues/5002

Edit: While "popper" works in the drawer, it is technically a workaround since it does change the behavior... See example in issue linked.