### PR TITLE
Use `uv` to simplify the local setup instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ We recommend using a virtual environment with Python 3.10 or higher to run this 
 
     *Open the browser and go to `http://localhost:3000/` to see the website.*
 
+**`uv` alternative**
+
+Run the project with `uv` using:
+
+```bash
+uv run --with-requirements requirements.txt reflex run
+```
+
+or
+
+```bash
+uv venv
+uv pip install -r requirements.txt
+uv run reflex run
+```
+
+
 ## Contributing
 
 We welcome contributions of any size!


### PR DESCRIPTION
Update the **Setup Locally** instructions to use `uv` instead of `venv`.

I'm pretty sure you are all using `uv` now for package management, and it seems like a good idea to recommend to others since it's so convenient to use. 

Note: the one liner `uv run --with-requirements ...` doesn't do hot-reloading (not sure why)... although the hot-reloading wasn't working well for me even with a full venv. I included instructions for methods of setup anyway.