### PR TITLE
Fix extra prop in h4_comp

### DIFF
--- a/pcweb/templates/docpage/blocks/headings.py
+++ b/pcweb/templates/docpage/blocks/headings.py
@@ -105,7 +105,6 @@ def h4_comp(text: str) -> rx.Component:
     return h_comp_common(
         text=text,
         heading="h4",
-        scroll_margin="6em",
         mt="2",
         class_name="font-md-smbold",
     )


### PR DESCRIPTION
This component isn't actually used anywhere, so we didn't notice that it was passing an unrecognized prop.