### PR TITLE
Add a clarification that models need to be imported for makemigrations to take effect

### DIFF
--- a/docs/database/overview.md
+++ b/docs/database/overview.md
@@ -60,8 +60,10 @@ to initialize alembic and create a migration script with the current schema.
 After making changes to the schema, use
 `reflex db makemigrations --message 'something changed'`
 to generate a script in the `alembic/versions` directory that will update the
-database schema. It is recommended that scripts be inspected before applying
-them.
+database schema.  It is recommended that generated scripts be inspected before applying them.
+
+Bear in mind that your newest models will not be detected by the `reflex db makemigrations`
+command unless imported and used somewhere within the application.
 
 The `reflex db migrate` command is used to apply migration scripts to bring the
 database up to date. During app startup, if Reflex detects that the current


### PR DESCRIPTION
As a newbie of Reflex and having worked with other web development frameworks like Rails, Laravel or Phoenix, when following the Database - Overview tutorial, got stuck more than I would have liked because `reflex db makemigrations` was not showing any changes or generating new migrations.
Turns out that this was due to the models declared under myapp/models/<model_name>.py were not imported anywhere yet.

Coming from those other frameworks you're used to not having to import the models to generate migrations, just having to declare the models and the migrations would get automatically generated, so I thought adding a simple clarification would surely help newcomers following the tutorial.