### PR TITLE
feat: redesign pricing cards with Team as popular plan and add anchor…

### DIFF
--- a/pcweb/pages/pricing/header.py
+++ b/pcweb/pages/pricing/header.py
@@ -9,8 +9,8 @@ def header() -> rx.Component:
             class_name="gradient-heading font-semibold text-3xl lg:text-5xl text-center",
         ),
         rx.el.p(
-            "Build with AI. Deploy with Cloud. Scale with Enterprise",
-            class_name="text-slate-9 text-lg lg:text-2xl font-semibold text-center",
+            "The complete platform for building and deploying your apps.",
+            class_name="text-slate-9 text-md lg:text-xl font-semibold text-center",
         ),
         class_name="flex flex-col gap-2 justify-center items-center max-w-[64.19rem] 2xl:border-x border-slate-4 w-full pb-16 "
         + rx.cond(HostingBannerState.show_banner, "pt-[11rem]", "pt-[8rem]"),

--- a/pcweb/pages/pricing/plan_cards.py
+++ b/pcweb/pages/pricing/plan_cards.py
@@ -143,8 +143,6 @@ def _get_price_label(title: str) -> str:
     """Get the appropriate price label for each plan."""
     if title == "Hobby":
         return "Free"
-    elif title == "Enterprise":
-        return ""  # No label for Enterprise (Custom pricing)
     else:
         return "From"
 
@@ -160,9 +158,10 @@ def _render_price_display(price: str, title: str) -> rx.Component:
             class_name="flex items-baseline"
         )
     else:
-        # Handle regular pricing (e.g., "$25/month")
+        # Handle regular pricing (e.g., "$25/month", "Custom")
         main_price = price.split("/")[0] if "/" in price else price
         period = f" / {price.split('/')[1]}" if "/" in price else ""
+        
         return rx.el.div(
             rx.el.span(main_price, class_name="text-4xl font-bold text-slate-12"),
             rx.el.span(period, class_name="text-sm text-slate-9"),
@@ -183,6 +182,11 @@ def _render_messaging_section(title: str) -> rx.Component:
             "sub": rx.link("Upgrade to Team for more messages", href="#reflex-build",
                           class_name="text-xs text-slate-9 hover:text-slate-11 underline")
         },
+        "Team": {
+            "main": "Reflex build 250 msgs/month",
+            "sub": rx.link("More messages available on request", href="#reflex-build",
+                          class_name="text-xs text-slate-9 hover:text-slate-11 underline")
+        },
         "Enterprise": {
             "main": "Reflex build 500+ msgs/month",
             "sub": rx.link("More messages available on request", href="#reflex-build",
@@ -193,7 +197,7 @@ def _render_messaging_section(title: str) -> rx.Component:
     if title in messaging_config:
         config = messaging_config[title]
         return rx.el.div(
-            rx.el.p(config["main"], class_name="text-sm font-medium text-slate-12 mt-4"),
+            rx.el.p(config["main"], class_name="text-md font-semibold text-slate-12 mt-4"),
             rx.el.p(config["sub"]) if title == "Hobby" else config["sub"],
             class_name="mt-4"
         )
@@ -321,11 +325,7 @@ def popular_card(
             rx.el.div(
                 rx.el.span("From", class_name="text-sm text-slate-9 block mb-1"),
                 _render_price_display(price, title),
-                rx.el.div(
-                    rx.el.p("Reflex build 250 msgs/month", class_name="text-sm font-medium text-slate-12 mt-4"),
-                    rx.link("More messages available on request", href="#reflex-build", class_name="text-xs text-slate-9 hover:text-slate-11 underline"),
-                    class_name="mt-4"
-                ),
+                _render_messaging_section(title),
                 class_name="mb-6"
             ),
             
@@ -380,7 +380,7 @@ def plan_cards() -> rx.Component:
             "Team",
             "For teams looking to scale their applications.",
             [   
-                ("credit-card", "Cloud Compute $20/mo included"),
+                ("credit-card", "Cloud Compute $20/month included"),
                 ("users", "Invite your teammates"),
                 (
                     "cable",

--- a/pcweb/pages/pricing/plan_cards.py
+++ b/pcweb/pages/pricing/plan_cards.py
@@ -30,6 +30,7 @@ def radial_circle(violet: bool = False) -> rx.Component:
 
 
 def glow() -> rx.Component:
+    """Radial gradient glow effect for popular card."""
     return rx.html(
         """<svg xmlns="http://www.w3.org/2000/svg" width="502" height="580" viewBox="0 0 502 580" fill="none">
   <path d="M0 290C0 450.163 112.377 580 251 580C389.623 580 502 450.163 502 290C502 129.837 389.623 0 251 0C112.377 0 0 129.837 0 290Z" fill="url(#paint0_radial_13685_26666)"/>
@@ -45,6 +46,7 @@ def glow() -> rx.Component:
 
 
 def grid() -> rx.Component:
+    """Animated grid background for popular card."""
     return rx.html(
         """<svg width="326" height="472" viewBox="0 0 326 472" fill="none" xmlns="http://www.w3.org/2000/svg">
 <g clip-path="url(#clip0_13685_24040)">
@@ -137,6 +139,99 @@ def grid() -> rx.Component:
     )
 
 
+def _get_price_label(title: str) -> str:
+    """Get the appropriate price label for each plan."""
+    if title == "Hobby":
+        return "Free"
+    elif title == "Enterprise":
+        return ""  # No label for Enterprise (Custom pricing)
+    else:
+        return "From"
+
+
+def _render_price_display(price: str, title: str) -> rx.Component:
+    """Render the price display section with proper formatting."""
+    if "user" in price:
+        # Handle user-based pricing (e.g., "$49 user/month")
+        parts = price.split(" ", 1)
+        return rx.el.div(
+            rx.el.span(parts[0], class_name="text-4xl font-bold text-slate-12"),
+            rx.el.span(f"  {parts[1]}", class_name="text-sm text-slate-9 ml-2"),
+            class_name="flex items-baseline"
+        )
+    else:
+        # Handle regular pricing (e.g., "$25/month")
+        main_price = price.split("/")[0] if "/" in price else price
+        period = f" / {price.split('/')[1]}" if "/" in price else ""
+        return rx.el.div(
+            rx.el.span(main_price, class_name="text-4xl font-bold text-slate-12"),
+            rx.el.span(period, class_name="text-sm text-slate-9"),
+            class_name="flex items-baseline"
+        )
+
+
+def _render_messaging_section(title: str) -> rx.Component:
+    """Render the messaging/features section for each plan."""
+    messaging_config = {
+        "Hobby": {
+            "main": "Reflex build 5 msgs/day",
+            "sub": rx.link("Monthly cap 30 messages", href="#reflex-build", 
+                          class_name="text-xs text-slate-9 hover:text-slate-11 underline")
+        },
+        "Pro": {
+            "main": "Reflex build 100 msgs/month",
+            "sub": rx.link("Upgrade to Team for more messages", href="#reflex-build",
+                          class_name="text-xs text-slate-9 hover:text-slate-11 underline")
+        },
+        "Enterprise": {
+            "main": "Reflex build 500+ msgs/month",
+            "sub": rx.link("More messages available on request", href="#reflex-build",
+                          class_name="text-xs text-slate-9 hover:text-slate-11 underline")
+        }
+    }
+    
+    if title in messaging_config:
+        config = messaging_config[title]
+        return rx.el.div(
+            rx.el.p(config["main"], class_name="text-sm font-medium text-slate-12 mt-4"),
+            rx.el.p(config["sub"]) if title == "Hobby" else config["sub"],
+            class_name="mt-4"
+        )
+    else:
+        # Default spacing for plans without messaging section
+        return rx.el.div(class_name="h-[3.5rem]")
+
+
+def _get_features_header(title: str) -> str:
+    """Get the appropriate features section header for each plan."""
+    headers = {
+        "Hobby": "Get started with:",
+        "Pro": "Everything in the Free Plan, plus:",
+        "Team": "Everything in the Pro Plan, plus:",
+        "Enterprise": "Everything in Team, plus:"
+    }
+    return headers.get(title, "Features:")
+
+
+def _render_feature_list(features: list[tuple[str, str]]) -> rx.Component:
+    """Render the feature list with consistent styling."""
+    return rx.el.ul(
+        *[
+            rx.el.li(
+                rx.icon("check", class_name="!text-green-500", size=16),
+                feature[1],
+                rx.tooltip(
+                    rx.icon("info", class_name="!text-slate-9", size=12),
+                    content=feature[2],
+                ) if len(feature) == 3 else "",
+                class_name="text-sm font-medium text-slate-11 flex items-center gap-3 mb-2",
+            )
+            for feature in features
+        ],
+        class_name="flex flex-col",
+    )
+
+
 def card(
     title: str,
     description: str,
@@ -145,56 +240,43 @@ def card(
     price: str = None,
     redirect_url: str = None,
 ) -> rx.Component:
+    """Standard pricing card component."""
     return rx.box(
-        rx.el.div(
-            rx.el.h3(title, class_name="font-semibold text-slate-12 text-2xl"),
-            (
-                rx.badge(
-                    price,
-                    color_scheme="gray",
-                    size="3",
-                    class_name="font-medium 2xl:text-lg text-base w-fit",
-                )
-                if price
-                else rx.fragment()
-            ),
-            class_name="flex 2xl:items-center mb-2 2xl:gap-4 gap-2 2xl:flex-row flex-col",
-        ),
-        rx.el.p(
-            description, class_name="text-sm font-medium text-slate-9 mb-8 text-pretty"
-        ),
-        rx.el.ul(
-            *[
-                rx.el.li(
-                    rx.icon(feature[0], class_name="!text-slate-9", size=16),
-                    feature[1],
-                    (
-                        rx.tooltip(
-                            rx.icon("info", class_name="!text-slate-9", size=12),
-                            content=feature[2],
-                        )
-                        if len(feature) == 3
-                        else ""
-                    ),
-                    class_name="text-sm font-medium text-slate-11 flex items-center gap-3",
-                )
-                for feature in features
-            ],
-            class_name="flex flex-col gap-2",
-        ),
-        rx.box(class_name="flex-1"),
+        # Header
+        rx.el.h3(title, class_name="font-semibold text-slate-12 text-2xl mb-4"),
+        rx.el.p(description, class_name="text-sm font-medium text-slate-9 mb-6 text-pretty"),
+        
+        # CTA Button
         rx.link(
             button(
                 button_text,
                 variant="secondary",
                 size="lg",
-                class_name="w-full",
+                class_name="w-full mb-6",
             ),
             href=redirect_url,
             is_external=True,
             underline="none",
         ),
-        class_name="flex flex-col p-8 border border-slate-4 rounded-[1.125rem] shadow-small bg-slate-2 w-full min-w-0 h-[33.5rem] overflow-hidden",
+        
+        # Pricing Section
+        rx.el.div(
+            rx.el.span(_get_price_label(title), class_name="text-sm text-slate-9 block mb-1"),
+            _render_price_display(price, title),
+            _render_messaging_section(title),
+            class_name="mb-6"
+        ),
+        
+        # Divider
+        rx.el.hr(class_name="border-slate-3 mb-6"),
+        
+        # Features Section
+        rx.el.div(
+            rx.el.p(_get_features_header(title), class_name="text-sm font-medium text-slate-9 mb-4"),
+            _render_feature_list(features),
+        ),
+        
+        class_name="flex flex-col p-6 border border-slate-4 rounded-lg shadow-small bg-slate-2 w-full min-w-0 overflow-hidden h-[42rem]",
     )
 
 
@@ -205,62 +287,60 @@ def popular_card(
     button_text: str,
     price: str = None,
 ) -> rx.Component:
+    """Popular pricing card component with special styling and effects."""
     return rx.box(
+        # Popular Badge
         rx.box(
-            "Most popular",
+            "Most Popular",
             class_name="absolute top-[-0.75rem] left-8 rounded-md bg-[--violet-9] h-[1.5rem] text-sm font-medium text-center px-2 flex items-center justify-center text-[#FCFCFD] z-[10]",
         ),
+        
+        # Card Content with Background Effects
         rx.box(
             glow(),
             grid(),
-            rx.el.div(
-                rx.el.h3(title, class_name="font-semibold text-slate-12 text-2xl"),
-                (
-                    rx.badge(
-                        price,
-                        color_scheme="violet",
-                        size="3",
-                        class_name="font-medium 2xl:text-lg text-base w-fit",
-                    )
-                    if price
-                    else rx.fragment()
-                ),
-                class_name="flex 2xl:items-center mb-2 2xl:gap-4 gap-2 2xl:flex-row flex-col",
-            ),
-            rx.el.p(description, class_name="text-sm font-medium text-slate-9 mb-8"),
-            rx.el.ul(
-                *[
-                    rx.el.li(
-                        rx.icon(feature[0], class_name="!text-violet-9", size=16),
-                        feature[1],
-                        (
-                            rx.tooltip(
-                                rx.icon("info", class_name="!text-slate-9", size=12),
-                                content=feature[2],
-                            )
-                            if len(feature) == 3
-                            else ""
-                        ),
-                        class_name="text-sm font-medium text-slate-11 flex items-center gap-3",
-                    )
-                    for feature in features
-                ],
-                class_name="flex flex-col gap-2",
-            ),
-            rx.box(class_name="flex-1"),
+            
+            # Header
+            rx.el.h3(title, class_name="font-semibold text-slate-12 text-2xl mb-4"),
+            rx.el.p(description, class_name="text-sm font-medium text-slate-9 mb-6 text-pretty"),
+            
+            # CTA Button
             rx.link(
                 button(
                     button_text,
                     variant="primary",
                     size="lg",
-                    class_name="w-full !text-sm !font-semibold",
+                    class_name="w-full mb-6 !text-sm !font-semibold",
                 ),
                 href=f"{REFLEX_CLOUD_URL}/?redirect_url={REFLEX_CLOUD_URL}/billing/",
                 is_external=True,
                 underline="none",
             ),
-            class_name="flex flex-col p-8 border border-[--violet-9] rounded-[1.125rem] w-full min-w-0 h-[33.5rem] relative z-[1] backdrop-blur-[6px] bg-[rgba(249,_249,_251,_0.48)] dark:bg-[rgba(26,_27,_29,_0.48)] shadow-[0px_2px_5px_0px_rgba(28_32_36_0.03)] overflow-hidden",
+            
+            # Pricing Section
+            rx.el.div(
+                rx.el.span("From", class_name="text-sm text-slate-9 block mb-1"),
+                _render_price_display(price, title),
+                rx.el.div(
+                    rx.el.p("Reflex build 250 msgs/month", class_name="text-sm font-medium text-slate-12 mt-4"),
+                    rx.link("More messages available on request", href="#reflex-build", class_name="text-xs text-slate-9 hover:text-slate-11 underline"),
+                    class_name="mt-4"
+                ),
+                class_name="mb-6"
+            ),
+            
+            # Divider
+            rx.el.hr(class_name="border-slate-3 mb-6"),
+            
+            # Features Section
+            rx.el.div(
+                rx.el.p("Everything in the Pro Plan, plus:", class_name="text-sm font-medium text-slate-9 mb-4"),
+                _render_feature_list(features),
+            ),
+            
+            class_name="flex flex-col p-6 border-2 border-[--violet-9] rounded-lg w-full min-w-0 relative z-[1] backdrop-blur-[6px] bg-[rgba(249,_249,_251,_0.48)] dark:bg-[rgba(26,_27,_29,_0.48)] shadow-[0px_2px_5px_0px_rgba(28_32_36_0.03)] overflow-hidden h-[42rem]",
         ),
+        
         class_name="relative",
     )
 
@@ -271,69 +351,65 @@ def plan_cards() -> rx.Component:
             "Hobby",
             "Everything you need to get started.",
             [
-                ("frame", "Open Source Framework"),
-                ("brain", "AI App Builder (Limited Access)"),
                 (
                     "app-window",
-                    "Cloud Unlimited Apps",
+                    "Cloud Limited Apps",
                     "Free users are limited to 20 hours of 1 vCPU, 1 GB RAM  machines per month.",
                 ),
-                ("code", "Reflex Open Source"),
                 ("heart-handshake", "Discord/Github Support"),
                 ("building", rx.link("Reflex Enterprise", href="https://reflex.dev/docs/enterprise/overview/", class_name="!text-slate-11"), "Free-tier users can access Reflex Enterprise features, with a required 'Built with Reflex' badge displayed on their apps."),
+                ("frame", "Open Source Framework"),
             ],
-            "Start building for free",
-            price="Free",
+            "Start for Free",
+            price="$0/month",
             redirect_url=REFLEX_DOCS_URL,
         ),
-        popular_card(
+        card(
             "Pro",
             "For professional projects and startups.",
             [
-                ("brain", "AI App Builder (Free $20 credits / month)"),
-                ("credit-card", "Cloud Compute (Free $10 credits / month)"),
+                ("credit-card", "Cloud Credits $10/month included"),
                 ("brush", "Custom domains"),
                 ("building", rx.link("Reflex Enterprise", href="https://reflex.dev/docs/enterprise/overview/", class_name="!text-slate-11"), "Pro-tier users can access Reflex Enterprise features without the 'Built with Reflex' badge when hosting their apps on Reflex Cloud"),
-                ("circle-plus", "Everything in Hobby"),
             ],
-            "Start with Pro plan",
-            price="$20/mo",
+            "Upgrade now",
+            price="$20/month",
+            redirect_url=f"{REFLEX_CLOUD_URL}/?redirect_url={REFLEX_CLOUD_URL}/billing/",
         ),
-        card(
+        popular_card(
             "Team",
             "For teams looking to scale their applications.",
-            [
-                ("users", "Invite your team mates"),
+            [   
+                ("credit-card", "Cloud Compute $20/mo included"),
+                ("users", "Invite your teammates"),
                 (
                     "cable",
-                    "Connect AI Builder to your Data",
-                    "Integrations include Databricks, Snowflake, etc.",
+                    "Reflex Build Integrations",
+                    "Databricks, Snowflake, etc.",
                 ),
-                ("credit-card", "Cloud Compute (Free $20 credits / user / month)"),
-                ("lock-keyhole", "One Click Auth"),
                 ("file-badge", "AG Grid with no Reflex Branding"),
                 ("mail", "Email support"),
                 ("building", rx.link("Reflex Enterprise", href="https://reflex.dev/docs/enterprise/overview/", class_name="!text-slate-11"), "Team-tier users can access Reflex Enterprise features without the 'Built with Reflex' badge when self-hosting their apps."),
-                ("circle-plus", "Everything in Pro"),
             ],
-            "Start with Team plan",
-            redirect_url=f"{REFLEX_CLOUD_URL}/?redirect_url={REFLEX_CLOUD_URL}/billing/",
-            price="$49/user/mo",
+            "Upgrade now",
+            price="$49 user/month",
         ),
         card(
             "Enterprise",
             "Get a plan tailored to your business needs.",
             [
+                ("credit-card", "Cloud Compute $100/mo included"),
+                ("hard-drive", "On Premise Deployment", "Option to self-host your apps on your own infrastructure."),
                 ("hand-helping", "White Glove Onboarding"),
                 ("user-round-plus", "Personalized integration help"),
-                ("hard-drive", "On Premise Deployment"),
                 ("key", "Bring your own AI API keys"),
                 ("headset", "Dedicated Support Channel"),
                 ("git-pull-request", "Influence Reflex Roadmap"),
                 ("circle-plus", "Everything in Team"),
             ],
-            "Contact sales",
+            "Contact Us",
+            price="Custom",
             redirect_url=REFLEX_DEV_WEB_LANDING_FORM_URL_GET_DEMO,
         ),
-        class_name="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-6"
+        class_name="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6"
     )

--- a/pcweb/pages/pricing/plan_cards.py
+++ b/pcweb/pages/pricing/plan_cards.py
@@ -173,22 +173,22 @@ def _render_messaging_section(title: str) -> rx.Component:
     """Render the messaging/features section for each plan."""
     messaging_config = {
         "Hobby": {
-            "main": "Reflex build 5 msgs/day",
+            "main": "Reflex Build 5 msgs/day",
             "sub": rx.link("Monthly cap 30 messages", href="#reflex-build", 
                           class_name="text-xs text-slate-9 hover:text-slate-11 underline")
         },
         "Pro": {
-            "main": "Reflex build 100 msgs/month",
+            "main": "Reflex Build 100 msgs/month",
             "sub": rx.link("Upgrade to Team for more messages", href="#reflex-build",
                           class_name="text-xs text-slate-9 hover:text-slate-11 underline")
         },
         "Team": {
-            "main": "Reflex build 250 msgs/month",
+            "main": "Reflex Build 250 msgs/month",
             "sub": rx.link("More messages available on request", href="#reflex-build",
                           class_name="text-xs text-slate-9 hover:text-slate-11 underline")
         },
         "Enterprise": {
-            "main": "Reflex build 500+ msgs/month",
+            "main": "Reflex Build 500+ msgs/month",
             "sub": rx.link("More messages available on request", href="#reflex-build",
                           class_name="text-xs text-slate-9 hover:text-slate-11 underline")
         }

--- a/pcweb/pages/pricing/table.py
+++ b/pcweb/pages/pricing/table.py
@@ -42,9 +42,9 @@ PRICE_SECTION = [
 AI_TEXT_SECTION = [
     (
         "Message Limit",
-        "30 msgs/mo",
-        "100 msgs/mo",
-        "250 msgs/mo",
+        "30 msgs/month",
+        "100 msgs/month",
+        "250 msgs/month",
         "Custom",
     ),
 ]

--- a/pcweb/pages/pricing/table.py
+++ b/pcweb/pages/pricing/table.py
@@ -41,15 +41,17 @@ PRICE_SECTION = [
 
 AI_TEXT_SECTION = [
     (
-        "AI App Building",
-        "Limited Access",
-        "$20 credits/month",
-        "$40 credits/user/month",
+        "Message Limit",
+        "30 msgs/mo",
+        "100 msgs/mo",
+        "250 msgs/mo",
         "Custom",
     ),
 ]
 
 AI_BOOLEAN_SECTION = [
+    ("Purchase Extra AI Messages", False, False, True, True),
+    ("Private Apps", False, True, True, True),
     ("Image to App", True, True, True, True),
     ("Web IDE", True, True, True, True),
     ("Custom User Rules", True, True, True, True),
@@ -57,8 +59,6 @@ AI_BOOLEAN_SECTION = [
     ("Github Integration", True, True, True, True),
     ("Database Integration", True, True, True, True),
     ("Secrets Integration", True, True, True, True),
-    ("Purchase Extra AI Credits", False, True, True, True),
-    ("Private Apps", False, True, True, True),
     ("Bring your own API Keys", False, False, False, True),
 ]
 
@@ -205,7 +205,23 @@ def create_table_row(cells: list) -> rx.Component:
     )
 
 
-def create_table_row_header(name: list, coming_soon: bool = False) -> rx.Component:
+def create_table_row_header(name: list, coming_soon: bool = False, anchor: str = None) -> rx.Component:
+    # Create row attributes
+    base_class = "w-full [&>*:not(:first-child)]:text-center bg-slate-2 border border-slate-3 rounded-2xl z-[6] !h-[3.625rem] relative align-content center"
+    
+    # Add scroll margin for anchor positioning
+    if anchor:
+        base_class += " scroll-mt-24"
+    
+    row_attrs = {
+        "class_name": base_class,
+        "padding_x": "5rem !important",
+    }
+    
+    # Add id attribute if anchor is provided
+    if anchor:
+        row_attrs["id"] = anchor
+    
     return rx.table.row(
         *[
             rx.table.column_header_cell(
@@ -225,8 +241,7 @@ def create_table_row_header(name: list, coming_soon: bool = False) -> rx.Compone
                 "Enterprise", class_name=STYLES["header_cell_sub"]
             ),
         ],
-        class_name="w-full [&>*:not(:first-child)]:text-center bg-slate-2 border border-slate-3 rounded-2xl z-[6] !h-[3.625rem] relative align-content center",
-        padding_x="5rem !important",
+        **row_attrs
     )
 
 
@@ -275,7 +290,7 @@ def table_body_oss() -> rx.Component:
             *[create_table_row(row) for row in PRICE_SECTION],
         ),
         rx.table.header(
-            create_table_row_header("Reflex Build"),
+            create_table_row_header("Reflex Build", anchor="reflex-build"),
             class_name="relative",
         ),
         create_table_body(


### PR DESCRIPTION
… links - Restructured pricing cards layout: Title → Description → Button → Price → Features - Made Team the popular card instead of Pro plan with purple border and glow effects - Updated pricing: Pro to /month, Team to /user/month - Added messaging sections with Reflex Build limits and upgrade links - Improved feature lists and removed redundant features - Added helper functions for cleaner, more maintainable code - Fixed price display formatting and alignment - Added anchor link for Reflex Build section with proper scroll positioning