### PR TITLE
disable connection banner

### DIFF
--- a/pcweb/pcweb.py
+++ b/pcweb/pcweb.py
@@ -24,6 +24,7 @@ for doc, href in outblocks:
 app = rxe.App(
     style=styles.BASE_STYLE,
     stylesheets=styles.STYLESHEETS,
+    app_wraps={},
     theme=rx.theme(
         has_background=True,
         radius="large",


### PR DESCRIPTION
disables other stuff as well, but nothing we use in reflex-web