### PR TITLE
Add Descope Auth link to authentication overview docs

### DIFF
--- a/blog/2024-12-20-python-comparison.md
+++ b/blog/2024-12-20-python-comparison.md
@@ -50,7 +50,7 @@ rx.vstack(
 - **No boilerplate**: Reflex handles the connection between your frontend and backend.
 - **Flexible and expressive**: Reflex comes with over 60 UI components that are highly customizable (supporting Tailwind, custom CSS, etc.).
 - **Database management**: Reflex integrates with SQLAlchemy and offers first-class support for SQLite, Postgres, and MySQL.
-- **Authentication**: Reflex offers multiple authentication options, including Local Auth, Google Auth, Captcha, Magic Link Auth, and Clerk Auth, allowing for easy user management.
+- **Authentication**: Reflex offers multiple authentication options, including Local Auth, Google Auth, Captcha, Magic Link Auth, Descope Auth, and Clerk Auth, allowing for easy user management.
 - **Deployment**: Reflex apps can be deployed to the cloud with a single command (`reflex deploy`).
 
 **Cons**

--- a/docs/authentication/authentication_overview.md
+++ b/docs/authentication/authentication_overview.md
@@ -13,6 +13,7 @@ We have solutions that currently exist outside of the core framework:
 3. Captcha: Generates tests that humans can pass but automated systems cannot: https://github.com/masenf/reflex-google-recaptcha-v2
 4. Magic Link Auth: A passwordless login method that sends a unique, one-time-use URL to a user's email: https://github.com/masenf/reflex-magic-link-auth
 5. Clerk Auth: A community member wrapped this component and hooked it up in this app: https://github.com/TimChild/reflex-clerk-api
+6. Descope Auth: Enables authentication with Descope, supporting passwordless, social login, SSO, and MFA: https://github.com/descope-sample-apps/reflex-descope-auth
 
 ## Guidance for Implementing Authentication
 


### PR DESCRIPTION
Adds an example for using Descope as an authentication provider in Reflex.